### PR TITLE
feat: Integrar backend com serviços de rotas. Closes #51

### DIFF
--- a/backend/app/controllers/route_controller.py
+++ b/backend/app/controllers/route_controller.py
@@ -1,59 +1,18 @@
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, status
 from typing import Any, Dict
+from app.schemas.route_schema import validate_route_payload, SafeRouteResponse
 
 router = APIRouter(prefix="/api/routes", tags=["Rotas Seguras"])
 
-@router.post("/safe", status_code=status.HTTP_200_OK)
+@router.post("/safe", response_model=SafeRouteResponse, status_code=status.HTTP_200_OK)
 def calculate_safe_route(payload: Dict[str, Any]):
-    # 1. Validar presença de origem e destino
-    if "origin" not in payload or payload["origin"] is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Origin is required"
-        )
-    if "destination" not in payload or payload["destination"] is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Destination is required"
-        )
+    """
+    Recebe origem e destino e inicia o cálculo de uma rota segura.
+    """
+    # Valida o payload de entrada e extrai os schemas das coordenadas
+    origin, destination = validate_route_payload(payload)
 
-    origin = payload["origin"]
-    destination = payload["destination"]
-
-    # 2. Validar se são dicionários e contêm latitude e longitude
-    if not isinstance(origin, dict) or "latitude" not in origin or "longitude" not in origin:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Origin must contain latitude and longitude"
-        )
-    if not isinstance(destination, dict) or "latitude" not in destination or "longitude" not in destination:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Destination must contain latitude and longitude"
-        )
-
-    # 3. Validar tipos e limites das coordenadas
-    try:
-        lat_org = float(origin["latitude"])
-        lng_org = float(origin["longitude"])
-        lat_dst = float(destination["latitude"])
-        lng_dst = float(destination["longitude"])
-    except (ValueError, TypeError):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Coordinates must be numbers"
-        )
-
-    if not (-90.0 <= lat_org <= 90.0) or not (-90.0 <= lat_dst <= 90.0):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Latitude must be between -90 and 90"
-        )
-    if not (-180.0 <= lng_org <= 180.0) or not (-180.0 <= lng_dst <= 180.0):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Longitude must be between -180 and 180"
-        )
-
-    # Mínimo para passar no teste da etapa GREEN
+    # Nota: Lógica futura de roteamento/serviço será injetada aqui.
+    
     return {"status": "success"}
+

--- a/backend/app/controllers/route_controller.py
+++ b/backend/app/controllers/route_controller.py
@@ -1,0 +1,59 @@
+from fastapi import APIRouter, HTTPException, status
+from typing import Any, Dict
+
+router = APIRouter(prefix="/api/routes", tags=["Rotas Seguras"])
+
+@router.post("/safe", status_code=status.HTTP_200_OK)
+def calculate_safe_route(payload: Dict[str, Any]):
+    # 1. Validar presença de origem e destino
+    if "origin" not in payload or payload["origin"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Origin is required"
+        )
+    if "destination" not in payload or payload["destination"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Destination is required"
+        )
+
+    origin = payload["origin"]
+    destination = payload["destination"]
+
+    # 2. Validar se são dicionários e contêm latitude e longitude
+    if not isinstance(origin, dict) or "latitude" not in origin or "longitude" not in origin:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Origin must contain latitude and longitude"
+        )
+    if not isinstance(destination, dict) or "latitude" not in destination or "longitude" not in destination:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Destination must contain latitude and longitude"
+        )
+
+    # 3. Validar tipos e limites das coordenadas
+    try:
+        lat_org = float(origin["latitude"])
+        lng_org = float(origin["longitude"])
+        lat_dst = float(destination["latitude"])
+        lng_dst = float(destination["longitude"])
+    except (ValueError, TypeError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Coordinates must be numbers"
+        )
+
+    if not (-90.0 <= lat_org <= 90.0) or not (-90.0 <= lat_dst <= 90.0):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Latitude must be between -90 and 90"
+        )
+    if not (-180.0 <= lng_org <= 180.0) or not (-180.0 <= lng_dst <= 180.0):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Longitude must be between -180 and 180"
+        )
+
+    # Mínimo para passar no teste da etapa GREEN
+    return {"status": "success"}

--- a/backend/app/controllers/route_controller.py
+++ b/backend/app/controllers/route_controller.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, status
 from typing import Any, Dict
 from app.schemas.route_schema import validate_route_payload, SafeRouteResponse
+from app.services.open_route_service import OpenRouteServiceClient
 
 router = APIRouter(prefix="/api/routes", tags=["Rotas Seguras"])
 
@@ -12,7 +13,29 @@ def calculate_safe_route(payload: Dict[str, Any]):
     # Valida o payload de entrada e extrai os schemas das coordenadas
     origin, destination = validate_route_payload(payload)
 
-    # Nota: Lógica futura de roteamento/serviço será injetada aqui.
-    
-    return {"status": "success"}
+    # Invoca o client do OpenRouteService para obter a rota
+    client = OpenRouteServiceClient()
+    data = client.get_route(
+        origin_lat=origin.latitude,
+        origin_lng=origin.longitude,
+        dest_lat=destination.latitude,
+        dest_lng=destination.longitude
+    )
+
+    # Extrai os dados da resposta GeoJSON
+    feature = data["features"][0]
+    distance = feature["properties"]["summary"]["distance"]
+    duration = feature["properties"]["summary"]["duration"]
+    coordinates = feature["geometry"]["coordinates"]
+
+    # Converte as coordenadas [longitude, latitude] para o formato do projeto
+    geometry = [{"latitude": lat, "longitude": lng} for lng, lat in coordinates]
+
+    return {
+        "status": "success",
+        "distance": distance,
+        "duration": duration,
+        "geometry": geometry
+    }
+
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,6 @@
+from dotenv import load_dotenv
+load_dotenv()
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.controllers.review_controller import router as review_router

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.controllers.review_controller import router as review_router
 from app.controllers.risk_controller import router as risk_router
 from app.controllers import alert_controller
+from app.controllers.route_controller import router as route_router
 
 app = FastAPI(title="Rua Segura API")
 
@@ -17,6 +18,7 @@ app.add_middleware(
 app.include_router(review_router)
 app.include_router(risk_router)
 app.include_router(alert_controller.router)
+app.include_router(route_router)
 
 @app.get("/")
 def read_root():

--- a/backend/app/schemas/route_schema.py
+++ b/backend/app/schemas/route_schema.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 from fastapi import HTTPException, status
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 class CoordinateSchema(BaseModel):
     latitude: float = Field(..., description="Latitude da coordenada")
@@ -8,6 +8,9 @@ class CoordinateSchema(BaseModel):
 
 class SafeRouteResponse(BaseModel):
     status: str = Field(..., description="Status do cálculo da rota")
+    distance: float = Field(..., description="Distância da rota em metros")
+    duration: float = Field(..., description="Duração estimada em segundos")
+    geometry: List[CoordinateSchema] = Field(..., description="Lista de coordenadas que compõem a rota")
 
 def validate_route_payload(payload: Dict[str, Any]) -> tuple[CoordinateSchema, CoordinateSchema]:
     """

--- a/backend/app/schemas/route_schema.py
+++ b/backend/app/schemas/route_schema.py
@@ -1,0 +1,71 @@
+from pydantic import BaseModel, Field
+from fastapi import HTTPException, status
+from typing import Any, Dict
+
+class CoordinateSchema(BaseModel):
+    latitude: float = Field(..., description="Latitude da coordenada")
+    longitude: float = Field(..., description="Longitude da coordenada")
+
+class SafeRouteResponse(BaseModel):
+    status: str = Field(..., description="Status do cálculo da rota")
+
+def validate_route_payload(payload: Dict[str, Any]) -> tuple[CoordinateSchema, CoordinateSchema]:
+    """
+    Valida o payload de entrada do cálculo de rota segura, gerando erros HTTP específicos
+    para manter conformidade com os testes automatizados da issue #47.
+    """
+    # 1. Validação de presença
+    if "origin" not in payload or payload["origin"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Origin is required"
+        )
+    if "destination" not in payload or payload["destination"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Destination is required"
+        )
+
+    origin = payload["origin"]
+    destination = payload["destination"]
+
+    # 2. Validação do tipo objeto e presença de campos específicos
+    if not isinstance(origin, dict) or "latitude" not in origin or "longitude" not in origin:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Origin must contain latitude and longitude"
+        )
+    if not isinstance(destination, dict) or "latitude" not in destination or "longitude" not in destination:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Destination must contain latitude and longitude"
+        )
+
+    # 3. Validação se são números válidos (ou strings numéricas conversíveis)
+    try:
+        lat_org = float(origin["latitude"])
+        lng_org = float(origin["longitude"])
+        lat_dst = float(destination["latitude"])
+        lng_dst = float(destination["longitude"])
+    except (ValueError, TypeError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Coordinates must be numbers"
+        )
+
+    # 4. Validação dos limites geográficos
+    if not (-90.0 <= lat_org <= 90.0) or not (-90.0 <= lat_dst <= 90.0):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Latitude must be between -90 and 90"
+        )
+    if not (-180.0 <= lng_org <= 180.0) or not (-180.0 <= lng_dst <= 180.0):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Longitude must be between -180 and 180"
+        )
+
+    return (
+        CoordinateSchema(latitude=lat_org, longitude=lng_org),
+        CoordinateSchema(latitude=lat_dst, longitude=lng_dst)
+    )

--- a/backend/app/services/open_route_service.py
+++ b/backend/app/services/open_route_service.py
@@ -1,0 +1,27 @@
+import httpx
+import os
+from typing import Any, Dict
+
+class OpenRouteServiceClient:
+    def __init__(self) -> None:
+        self.api_key = os.getenv("ORS_API_KEY")
+        self.base_url = "https://api.openrouteservice.org/v2/directions/driving-car/geojson"
+
+    def get_route(self, origin_lat: float, origin_lng: float, dest_lat: float, dest_lng: float) -> Dict[str, Any]:
+        """
+        Busca a rota no OpenRouteService.
+        """
+        # Esqueleto inicial para o ciclo RED 1.
+        # A chamada HTTP real usará httpx.post e será mockada nos testes.
+        headers = {
+            "Authorization": self.api_key,
+            "Content-Type": "application/json"
+        }
+        payload = {
+            "coordinates": [
+                [origin_lng, origin_lat],
+                [dest_lng, dest_lat]
+            ]
+        }
+        response = httpx.post(self.base_url, headers=headers, json=payload)
+        return response.json()

--- a/backend/app/services/open_route_service.py
+++ b/backend/app/services/open_route_service.py
@@ -2,17 +2,17 @@ import httpx
 import os
 from typing import Any, Dict
 
+ORS_BASE_URL = "https://api.openrouteservice.org/v2/directions/driving-car/geojson"
+
 class OpenRouteServiceClient:
     def __init__(self) -> None:
         self.api_key = os.getenv("ORS_API_KEY")
-        self.base_url = "https://api.openrouteservice.org/v2/directions/driving-car/geojson"
+        self.base_url = ORS_BASE_URL
 
     def get_route(self, origin_lat: float, origin_lng: float, dest_lat: float, dest_lng: float) -> Dict[str, Any]:
         """
-        Busca a rota no OpenRouteService.
+        Busca as direções de uma rota no OpenRouteService via API HTTP.
         """
-        # Esqueleto inicial para o ciclo RED 1.
-        # A chamada HTTP real usará httpx.post e será mockada nos testes.
         headers = {
             "Authorization": self.api_key,
             "Content-Type": "application/json"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,4 @@
 fastapi>=0.110.0
 uvicorn[standard]>=0.28.0
+pytest>=8.0.0
+httpx2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.110.0
 uvicorn[standard]>=0.28.0
 pytest>=8.0.0
-httpx2
+httpx
+python-dotenv

--- a/backend/tests/test_safe_route.py
+++ b/backend/tests/test_safe_route.py
@@ -1,0 +1,119 @@
+import unittest
+from fastapi.testclient import TestClient
+from app.main import app
+
+class TestSafeRouteEndpoints(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        self.endpoint = "/api/routes/safe"
+
+    def test_calculate_safe_route_success(self):
+        """
+        Deve enviar uma requisição POST válida para o endpoint de rota segura.
+        Esperar uma resposta de sucesso no futuro (status 200).
+        Este teste deve falhar agora com 404 (ou similar) pois o endpoint não existe.
+        """
+        payload = {
+            "origin": {
+                "latitude": -5.0930,
+                "longitude": -42.8060
+            },
+            "destination": {
+                "latitude": -5.0945,
+                "longitude": -42.8080
+            }
+        }
+        response = self.client.post(self.endpoint, json=payload)
+        # TDD RED: Deve falhar pois o endpoint não existe e retornará 404
+        self.assertEqual(response.status_code, 200)
+
+    def test_missing_origin(self):
+        """
+        Deve validar a obrigatoriedade da origem.
+        Enviar requisição sem origem e esperar erro 400 no futuro.
+        """
+        payload = {
+            "destination": {
+                "latitude": -5.0945,
+                "longitude": -42.8080
+            }
+        }
+        response = self.client.post(self.endpoint, json=payload)
+        # TDD RED: Deve falhar pois o endpoint não existe e retornará 404 (ou similar) em vez de 400
+        self.assertEqual(response.status_code, 400)
+
+    def test_missing_destination(self):
+        """
+        Deve validar a obrigatoriedade do destino.
+        Enviar requisição sem destino e esperar erro 400 no futuro.
+        """
+        payload = {
+            "origin": {
+                "latitude": -5.0930,
+                "longitude": -42.8060
+            }
+        }
+        response = self.client.post(self.endpoint, json=payload)
+        # TDD RED: Deve falhar pois o endpoint não existe e retornará 404 (ou similar) em vez de 400
+        self.assertEqual(response.status_code, 400)
+
+    def test_invalid_coordinates(self):
+        """
+        Deve validar coordenadas inválidas (latitude e longitude fora do intervalo).
+        Latitude fora de [-90, 90] ou Longitude fora de [-180, 180] devem retornar erro 400 no futuro.
+        """
+        # Latitude da origem fora do intervalo (-91.0)
+        payload_invalid_lat_origin = {
+            "origin": {
+                "latitude": -91.0,
+                "longitude": -42.8060
+            },
+            "destination": {
+                "latitude": -5.0945,
+                "longitude": -42.8080
+            }
+        }
+        response = self.client.post(self.endpoint, json=payload_invalid_lat_origin)
+        self.assertEqual(response.status_code, 400)
+
+        # Longitude da origem fora do intervalo (181.0)
+        payload_invalid_lng_origin = {
+            "origin": {
+                "latitude": -5.0930,
+                "longitude": 181.0
+            },
+            "destination": {
+                "latitude": -5.0945,
+                "longitude": -42.8080
+            }
+        }
+        response = self.client.post(self.endpoint, json=payload_invalid_lng_origin)
+        self.assertEqual(response.status_code, 400)
+
+        # Latitude do destino fora do intervalo (95.0)
+        payload_invalid_lat_dest = {
+            "origin": {
+                "latitude": -5.0930,
+                "longitude": -42.8060
+            },
+            "destination": {
+                "latitude": 95.0,
+                "longitude": -42.8080
+            }
+        }
+        response = self.client.post(self.endpoint, json=payload_invalid_lat_dest)
+        self.assertEqual(response.status_code, 400)
+
+        # Longitude do destino fora do intervalo (-185.0)
+        payload_invalid_lng_dest = {
+            "origin": {
+                "latitude": -5.0930,
+                "longitude": -42.8060
+            },
+            "destination": {
+                "latitude": -5.0945,
+                "longitude": -185.0
+            }
+        }
+        response = self.client.post(self.endpoint, json=payload_invalid_lng_dest)
+        self.assertEqual(response.status_code, 400)

--- a/backend/tests/test_safe_route.py
+++ b/backend/tests/test_safe_route.py
@@ -1,19 +1,17 @@
 import unittest
+
 from fastapi.testclient import TestClient
+
 from app.main import app
+
 
 class TestSafeRouteEndpoints(unittest.TestCase):
     def setUp(self):
         self.client = TestClient(app)
         self.endpoint = "/api/routes/safe"
 
-    def test_calculate_safe_route_success(self):
-        """
-        Deve enviar uma requisição POST válida para o endpoint de rota segura.
-        Esperar uma resposta de sucesso no futuro (status 200).
-        Este teste deve falhar agora com 404 (ou similar) pois o endpoint não existe.
-        """
-        payload = {
+    def _valid_payload(self):
+        return {
             "origin": {
                 "latitude": -5.0930,
                 "longitude": -42.8060
@@ -23,97 +21,162 @@ class TestSafeRouteEndpoints(unittest.TestCase):
                 "longitude": -42.8080
             }
         }
+
+    def _assert_bad_request(self, payload, detail):
         response = self.client.post(self.endpoint, json=payload)
-        # TDD RED: Deve falhar pois o endpoint não existe e retornará 404
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"detail": detail})
+
+    def test_calculate_safe_route_success(self):
+        response = self.client.post(self.endpoint, json=self._valid_payload())
+
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "success"})
+
+    def test_calculate_safe_route_accepts_coordinate_boundaries(self):
+        payload = {
+            "origin": {
+                "latitude": -90.0,
+                "longitude": -180.0
+            },
+            "destination": {
+                "latitude": 90.0,
+                "longitude": 180.0
+            }
+        }
+
+        response = self.client.post(self.endpoint, json=payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "success"})
+
+    def test_calculate_safe_route_accepts_numeric_strings(self):
+        payload = {
+            "origin": {
+                "latitude": "-5.0930",
+                "longitude": "-42.8060"
+            },
+            "destination": {
+                "latitude": "-5.0945",
+                "longitude": "-42.8080"
+            }
+        }
+
+        response = self.client.post(self.endpoint, json=payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "success"})
 
     def test_missing_origin(self):
-        """
-        Deve validar a obrigatoriedade da origem.
-        Enviar requisição sem origem e esperar erro 400 no futuro.
-        """
         payload = {
             "destination": {
                 "latitude": -5.0945,
                 "longitude": -42.8080
             }
         }
-        response = self.client.post(self.endpoint, json=payload)
-        # TDD RED: Deve falhar pois o endpoint não existe e retornará 404 (ou similar) em vez de 400
-        self.assertEqual(response.status_code, 400)
+
+        self._assert_bad_request(payload, "Origin is required")
+
+    def test_null_origin(self):
+        payload = self._valid_payload()
+        payload["origin"] = None
+
+        self._assert_bad_request(payload, "Origin is required")
 
     def test_missing_destination(self):
-        """
-        Deve validar a obrigatoriedade do destino.
-        Enviar requisição sem destino e esperar erro 400 no futuro.
-        """
         payload = {
             "origin": {
                 "latitude": -5.0930,
                 "longitude": -42.8060
             }
         }
-        response = self.client.post(self.endpoint, json=payload)
-        # TDD RED: Deve falhar pois o endpoint não existe e retornará 404 (ou similar) em vez de 400
-        self.assertEqual(response.status_code, 400)
+
+        self._assert_bad_request(payload, "Destination is required")
+
+    def test_null_destination(self):
+        payload = self._valid_payload()
+        payload["destination"] = None
+
+        self._assert_bad_request(payload, "Destination is required")
+
+    def test_origin_must_be_object_with_latitude_and_longitude(self):
+        invalid_payloads = [
+            {
+                "origin": "Teresina",
+                "destination": self._valid_payload()["destination"]
+            },
+            {
+                "origin": {"latitude": -5.0930},
+                "destination": self._valid_payload()["destination"]
+            },
+            {
+                "origin": {"longitude": -42.8060},
+                "destination": self._valid_payload()["destination"]
+            }
+        ]
+
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                self._assert_bad_request(
+                    payload,
+                    "Origin must contain latitude and longitude"
+                )
+
+    def test_destination_must_be_object_with_latitude_and_longitude(self):
+        invalid_payloads = [
+            {
+                "origin": self._valid_payload()["origin"],
+                "destination": "Teresina"
+            },
+            {
+                "origin": self._valid_payload()["origin"],
+                "destination": {"latitude": -5.0945}
+            },
+            {
+                "origin": self._valid_payload()["origin"],
+                "destination": {"longitude": -42.8080}
+            }
+        ]
+
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                self._assert_bad_request(
+                    payload,
+                    "Destination must contain latitude and longitude"
+                )
+
+    def test_coordinates_must_be_numbers(self):
+        invalid_cases = [
+            ("origin", "latitude"),
+            ("origin", "longitude"),
+            ("destination", "latitude"),
+            ("destination", "longitude")
+        ]
+
+        for point, coordinate in invalid_cases:
+            payload = self._valid_payload()
+            payload[point][coordinate] = "invalid"
+
+            with self.subTest(point=point, coordinate=coordinate):
+                self._assert_bad_request(payload, "Coordinates must be numbers")
 
     def test_invalid_coordinates(self):
-        """
-        Deve validar coordenadas inválidas (latitude e longitude fora do intervalo).
-        Latitude fora de [-90, 90] ou Longitude fora de [-180, 180] devem retornar erro 400 no futuro.
-        """
-        # Latitude da origem fora do intervalo (-91.0)
-        payload_invalid_lat_origin = {
-            "origin": {
-                "latitude": -91.0,
-                "longitude": -42.8060
-            },
-            "destination": {
-                "latitude": -5.0945,
-                "longitude": -42.8080
-            }
-        }
-        response = self.client.post(self.endpoint, json=payload_invalid_lat_origin)
-        self.assertEqual(response.status_code, 400)
+        invalid_cases = [
+            ("origin", "latitude", -91.0, "Latitude must be between -90 and 90"),
+            ("origin", "longitude", 181.0, "Longitude must be between -180 and 180"),
+            ("destination", "latitude", 95.0, "Latitude must be between -90 and 90"),
+            ("destination", "longitude", -185.0, "Longitude must be between -180 and 180")
+        ]
 
-        # Longitude da origem fora do intervalo (181.0)
-        payload_invalid_lng_origin = {
-            "origin": {
-                "latitude": -5.0930,
-                "longitude": 181.0
-            },
-            "destination": {
-                "latitude": -5.0945,
-                "longitude": -42.8080
-            }
-        }
-        response = self.client.post(self.endpoint, json=payload_invalid_lng_origin)
-        self.assertEqual(response.status_code, 400)
+        for point, coordinate, value, detail in invalid_cases:
+            payload = self._valid_payload()
+            payload[point][coordinate] = value
 
-        # Latitude do destino fora do intervalo (95.0)
-        payload_invalid_lat_dest = {
-            "origin": {
-                "latitude": -5.0930,
-                "longitude": -42.8060
-            },
-            "destination": {
-                "latitude": 95.0,
-                "longitude": -42.8080
-            }
-        }
-        response = self.client.post(self.endpoint, json=payload_invalid_lat_dest)
-        self.assertEqual(response.status_code, 400)
+            with self.subTest(point=point, coordinate=coordinate, value=value):
+                self._assert_bad_request(payload, detail)
 
-        # Longitude do destino fora do intervalo (-185.0)
-        payload_invalid_lng_dest = {
-            "origin": {
-                "latitude": -5.0930,
-                "longitude": -42.8060
-            },
-            "destination": {
-                "latitude": -5.0945,
-                "longitude": -185.0
-            }
-        }
-        response = self.client.post(self.endpoint, json=payload_invalid_lng_dest)
-        self.assertEqual(response.status_code, 400)
+    def test_safe_route_endpoint_only_accepts_post(self):
+        response = self.client.get(self.endpoint)
+
+        self.assertEqual(response.status_code, 405)

--- a/backend/tests/test_safe_route.py
+++ b/backend/tests/test_safe_route.py
@@ -12,6 +12,38 @@ class TestSafeRouteEndpoints(unittest.TestCase):
         self.client = TestClient(app)
         self.endpoint = "/api/routes/safe"
 
+        from unittest.mock import patch, MagicMock
+        self.patcher = patch("app.services.open_route_service.httpx.post")
+        self.mock_post = self.patcher.start()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "summary": {
+                            "distance": 1000.0,
+                            "duration": 300.0,
+                        }
+                    },
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [
+                            [-42.8060, -5.0930],
+                            [-42.8080, -5.0945],
+                        ],
+                    },
+                }
+            ],
+        }
+        self.mock_post.return_value = mock_response
+
+    def tearDown(self):
+        self.patcher.stop()
+
     def _valid_payload(self):
         return {
             "origin": {
@@ -34,7 +66,14 @@ class TestSafeRouteEndpoints(unittest.TestCase):
         response = self.client.post(self.endpoint, json=self._valid_payload())
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"status": "success"})
+        data = response.json()
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["distance"], 1000.0)
+        self.assertEqual(data["duration"], 300.0)
+        self.assertEqual(data["geometry"], [
+            {"latitude": -5.0930, "longitude": -42.8060},
+            {"latitude": -5.0945, "longitude": -42.8080}
+        ])
 
     def test_calculate_safe_route_accepts_coordinate_boundaries(self):
         payload = {
@@ -48,10 +87,24 @@ class TestSafeRouteEndpoints(unittest.TestCase):
             }
         }
 
+        # Ajusta mock para as coordenadas limites
+        mock_response = self.mock_post.return_value
+        mock_response.json.return_value["features"][0]["geometry"]["coordinates"] = [
+            [-180.0, -90.0],
+            [180.0, 90.0]
+        ]
+
         response = self.client.post(self.endpoint, json=payload)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"status": "success"})
+        data = response.json()
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["distance"], 1000.0)
+        self.assertEqual(data["duration"], 300.0)
+        self.assertEqual(data["geometry"], [
+            {"latitude": -90.0, "longitude": -180.0},
+            {"latitude": 90.0, "longitude": 180.0}
+        ])
 
     def test_calculate_safe_route_accepts_numeric_strings(self):
         payload = {
@@ -68,7 +121,14 @@ class TestSafeRouteEndpoints(unittest.TestCase):
         response = self.client.post(self.endpoint, json=payload)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"status": "success"})
+        data = response.json()
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["distance"], 1000.0)
+        self.assertEqual(data["duration"], 300.0)
+        self.assertEqual(data["geometry"], [
+            {"latitude": -5.0930, "longitude": -42.8060},
+            {"latitude": -5.0945, "longitude": -42.8080}
+        ])
 
     def test_missing_origin(self):
         payload = {

--- a/backend/tests/test_safe_route.py
+++ b/backend/tests/test_safe_route.py
@@ -1,4 +1,6 @@
 import unittest
+# pyrefly: ignore [missing-import]
+import pytest
 
 from fastapi.testclient import TestClient
 
@@ -180,3 +182,89 @@ class TestSafeRouteEndpoints(unittest.TestCase):
         response = self.client.get(self.endpoint)
 
         self.assertEqual(response.status_code, 405)
+
+
+def test_safe_route_integration_with_open_route_service(monkeypatch):
+    client = TestClient(app)
+    endpoint = "/api/routes/safe"
+    
+    # Configurar chave de API de teste e mock do httpx.post
+    monkeypatch.setenv("ORS_API_KEY", "test-api-key")
+    
+    class FakeResponse:
+        def __init__(self, status_code, json_data):
+            self.status_code = status_code
+            self._json_data = json_data
+            
+        def json(self):
+            return self._json_data
+            
+    called = []
+    
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called.append((url, headers, json))
+        assert "/v2/directions/" in url
+        assert url.endswith("/geojson")
+        assert headers is not None
+        assert headers.get("Authorization") == "test-api-key"
+        assert json["coordinates"] == [
+            [-42.8016, -5.0892],
+            [-42.8100, -5.0920],
+        ]
+        return FakeResponse(
+            200,
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "summary": {
+                                "distance": 1250.5,
+                                "duration": 420.0,
+                            }
+                        },
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [
+                                [-42.8016, -5.0892],
+                                [-42.8050, -5.0901],
+                                [-42.8100, -5.0920],
+                            ],
+                        },
+                    }
+                ],
+            },
+        )
+        
+    monkeypatch.setattr("app.services.open_route_service.httpx.post", fake_post)
+    
+    payload = {
+        "origin": {
+            "latitude": -5.0892,
+            "longitude": -42.8016
+        },
+        "destination": {
+            "latitude": -5.0920,
+            "longitude": -42.8100
+        }
+    }
+    
+    response = client.post(endpoint, json=payload)
+    
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["distance"] == 1250.5
+    assert data["duration"] == 420.0
+    
+    # Validar que os pontos da rota foram convertidos e retornados no formato esperado
+    assert data["geometry"] == [
+        {"latitude": -5.0892, "longitude": -42.8016},
+        {"latitude": -5.0901, "longitude": -42.8050},
+        {"latitude": -5.0920, "longitude": -42.8100}
+    ]
+    
+    assert len(called) == 1
+


### PR DESCRIPTION
* **Integração com OpenRouteService**: Criado o client `OpenRouteServiceClient` utilizando `httpx` para fazer as requisições à API externa de rotas de forma dinâmica.
* **Gerenciamento de Segredos**: Adicionado suporte à biblioteca `python-dotenv` e configurado o startup em `main.py` para carregar a chave de API `ORS_API_KEY` a partir de um arquivo `.env` local.
* **Atualização do Contrato da API**: Alterada a resposta do endpoint `POST /api/routes/safe` no schema `SafeRouteResponse` e no controller para processar e retornar a distância, a duração estimada e a lista de coordenadas (`geometry`) da rota formatadas.
* **Testes de Integração e Mocks**: Desenvolvido um teste de integração mockando as chamadas HTTP (evitando conexões reais com a internet) e atualizados os testes de sucesso anteriores para validar a nova resposta estruturada.

Como testar:

Para rodar toda a **suíte de testes** (com todos os 22 testes passando):

Estando dentro do ambiente virtual da pasta backend:
`python -m pytest tests/test_safe_route.py -v`

**Teste Manual (API Real)**
Suba a API localmente com o .env configurado e dispare um cURL ou utilize ferramentas como Postman/Insomnia:

- Iniciar a API
`uvicorn app.main:app --reload`
- Disparar chamada via PowerShell usando Invoke-RestMethod ou curl.exe
```
Invoke-RestMethod -Uri "http://127.0.0.1:8000/api/routes/safe" `
                  -Method Post `
                  -Headers @{"Content-Type" = "application/json"} `
                  -Body '{"origin": {"latitude": -5.0892, "longitude": -42.8016}, "destination": {"latitude": -5.0920, "longitude": -42.8100}}'
```