### PR TITLE
feat: Integrar backend com serviços de rotas. Closes #51

### DIFF
--- a/backend/app/controllers/route_controller.py
+++ b/backend/app/controllers/route_controller.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, status
 from typing import Any, Dict
 from app.schemas.route_schema import validate_route_payload, SafeRouteResponse
+from app.services.open_route_service import OpenRouteServiceClient
 
 router = APIRouter(prefix="/api/routes", tags=["Rotas Seguras"])
 
@@ -12,7 +13,29 @@ def calculate_safe_route(payload: Dict[str, Any]):
     # Valida o payload de entrada e extrai os schemas das coordenadas
     origin, destination = validate_route_payload(payload)
 
-    # Nota: Lógica futura de roteamento/serviço será injetada aqui.
-    
-    return {"status": "success"}
+    # Invoca o client do OpenRouteService para obter a rota
+    client = OpenRouteServiceClient()
+    data = client.get_route(
+        origin_lat=origin.latitude,
+        origin_lng=origin.longitude,
+        dest_lat=destination.latitude,
+        dest_lng=destination.longitude
+    )
+
+    # Extrai os dados da resposta GeoJSON
+    feature = data["features"][0]
+    distance = feature["properties"]["summary"]["distance"]
+    duration = feature["properties"]["summary"]["duration"]
+    coordinates = feature["geometry"]["coordinates"]
+
+    # Converte as coordenadas [longitude, latitude] para o formato do projeto
+    geometry = [{"latitude": lat, "longitude": lng} for lng, lat in coordinates]
+
+    return {
+        "status": "success",
+        "distance": distance,
+        "duration": duration,
+        "geometry": geometry
+    }
+
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,6 @@
+from dotenv import load_dotenv
+load_dotenv()
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.controllers.review_controller import router as review_router

--- a/backend/app/schemas/route_schema.py
+++ b/backend/app/schemas/route_schema.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 from fastapi import HTTPException, status
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 class CoordinateSchema(BaseModel):
     latitude: float = Field(..., description="Latitude da coordenada")
@@ -8,6 +8,9 @@ class CoordinateSchema(BaseModel):
 
 class SafeRouteResponse(BaseModel):
     status: str = Field(..., description="Status do cálculo da rota")
+    distance: float = Field(..., description="Distância da rota em metros")
+    duration: float = Field(..., description="Duração estimada em segundos")
+    geometry: List[CoordinateSchema] = Field(..., description="Lista de coordenadas que compõem a rota")
 
 def validate_route_payload(payload: Dict[str, Any]) -> tuple[CoordinateSchema, CoordinateSchema]:
     """

--- a/backend/app/services/open_route_service.py
+++ b/backend/app/services/open_route_service.py
@@ -1,0 +1,27 @@
+import httpx
+import os
+from typing import Any, Dict
+
+class OpenRouteServiceClient:
+    def __init__(self) -> None:
+        self.api_key = os.getenv("ORS_API_KEY")
+        self.base_url = "https://api.openrouteservice.org/v2/directions/driving-car/geojson"
+
+    def get_route(self, origin_lat: float, origin_lng: float, dest_lat: float, dest_lng: float) -> Dict[str, Any]:
+        """
+        Busca a rota no OpenRouteService.
+        """
+        # Esqueleto inicial para o ciclo RED 1.
+        # A chamada HTTP real usará httpx.post e será mockada nos testes.
+        headers = {
+            "Authorization": self.api_key,
+            "Content-Type": "application/json"
+        }
+        payload = {
+            "coordinates": [
+                [origin_lng, origin_lat],
+                [dest_lng, dest_lat]
+            ]
+        }
+        response = httpx.post(self.base_url, headers=headers, json=payload)
+        return response.json()

--- a/backend/app/services/open_route_service.py
+++ b/backend/app/services/open_route_service.py
@@ -2,17 +2,17 @@ import httpx
 import os
 from typing import Any, Dict
 
+ORS_BASE_URL = "https://api.openrouteservice.org/v2/directions/driving-car/geojson"
+
 class OpenRouteServiceClient:
     def __init__(self) -> None:
         self.api_key = os.getenv("ORS_API_KEY")
-        self.base_url = "https://api.openrouteservice.org/v2/directions/driving-car/geojson"
+        self.base_url = ORS_BASE_URL
 
     def get_route(self, origin_lat: float, origin_lng: float, dest_lat: float, dest_lng: float) -> Dict[str, Any]:
         """
-        Busca a rota no OpenRouteService.
+        Busca as direções de uma rota no OpenRouteService via API HTTP.
         """
-        # Esqueleto inicial para o ciclo RED 1.
-        # A chamada HTTP real usará httpx.post e será mockada nos testes.
         headers = {
             "Authorization": self.api_key,
             "Content-Type": "application/json"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.110.0
 uvicorn[standard]>=0.28.0
 pytest>=8.0.0
-httpx2
+httpx
+python-dotenv

--- a/backend/tests/test_safe_route.py
+++ b/backend/tests/test_safe_route.py
@@ -12,6 +12,38 @@ class TestSafeRouteEndpoints(unittest.TestCase):
         self.client = TestClient(app)
         self.endpoint = "/api/routes/safe"
 
+        from unittest.mock import patch, MagicMock
+        self.patcher = patch("app.services.open_route_service.httpx.post")
+        self.mock_post = self.patcher.start()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "summary": {
+                            "distance": 1000.0,
+                            "duration": 300.0,
+                        }
+                    },
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [
+                            [-42.8060, -5.0930],
+                            [-42.8080, -5.0945],
+                        ],
+                    },
+                }
+            ],
+        }
+        self.mock_post.return_value = mock_response
+
+    def tearDown(self):
+        self.patcher.stop()
+
     def _valid_payload(self):
         return {
             "origin": {
@@ -34,7 +66,14 @@ class TestSafeRouteEndpoints(unittest.TestCase):
         response = self.client.post(self.endpoint, json=self._valid_payload())
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"status": "success"})
+        data = response.json()
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["distance"], 1000.0)
+        self.assertEqual(data["duration"], 300.0)
+        self.assertEqual(data["geometry"], [
+            {"latitude": -5.0930, "longitude": -42.8060},
+            {"latitude": -5.0945, "longitude": -42.8080}
+        ])
 
     def test_calculate_safe_route_accepts_coordinate_boundaries(self):
         payload = {
@@ -48,10 +87,24 @@ class TestSafeRouteEndpoints(unittest.TestCase):
             }
         }
 
+        # Ajusta mock para as coordenadas limites
+        mock_response = self.mock_post.return_value
+        mock_response.json.return_value["features"][0]["geometry"]["coordinates"] = [
+            [-180.0, -90.0],
+            [180.0, 90.0]
+        ]
+
         response = self.client.post(self.endpoint, json=payload)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"status": "success"})
+        data = response.json()
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["distance"], 1000.0)
+        self.assertEqual(data["duration"], 300.0)
+        self.assertEqual(data["geometry"], [
+            {"latitude": -90.0, "longitude": -180.0},
+            {"latitude": 90.0, "longitude": 180.0}
+        ])
 
     def test_calculate_safe_route_accepts_numeric_strings(self):
         payload = {
@@ -68,7 +121,14 @@ class TestSafeRouteEndpoints(unittest.TestCase):
         response = self.client.post(self.endpoint, json=payload)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"status": "success"})
+        data = response.json()
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["distance"], 1000.0)
+        self.assertEqual(data["duration"], 300.0)
+        self.assertEqual(data["geometry"], [
+            {"latitude": -5.0930, "longitude": -42.8060},
+            {"latitude": -5.0945, "longitude": -42.8080}
+        ])
 
     def test_missing_origin(self):
         payload = {

--- a/backend/tests/test_safe_route.py
+++ b/backend/tests/test_safe_route.py
@@ -1,4 +1,6 @@
 import unittest
+# pyrefly: ignore [missing-import]
+import pytest
 
 from fastapi.testclient import TestClient
 
@@ -180,3 +182,89 @@ class TestSafeRouteEndpoints(unittest.TestCase):
         response = self.client.get(self.endpoint)
 
         self.assertEqual(response.status_code, 405)
+
+
+def test_safe_route_integration_with_open_route_service(monkeypatch):
+    client = TestClient(app)
+    endpoint = "/api/routes/safe"
+    
+    # Configurar chave de API de teste e mock do httpx.post
+    monkeypatch.setenv("ORS_API_KEY", "test-api-key")
+    
+    class FakeResponse:
+        def __init__(self, status_code, json_data):
+            self.status_code = status_code
+            self._json_data = json_data
+            
+        def json(self):
+            return self._json_data
+            
+    called = []
+    
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called.append((url, headers, json))
+        assert "/v2/directions/" in url
+        assert url.endswith("/geojson")
+        assert headers is not None
+        assert headers.get("Authorization") == "test-api-key"
+        assert json["coordinates"] == [
+            [-42.8016, -5.0892],
+            [-42.8100, -5.0920],
+        ]
+        return FakeResponse(
+            200,
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "summary": {
+                                "distance": 1250.5,
+                                "duration": 420.0,
+                            }
+                        },
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [
+                                [-42.8016, -5.0892],
+                                [-42.8050, -5.0901],
+                                [-42.8100, -5.0920],
+                            ],
+                        },
+                    }
+                ],
+            },
+        )
+        
+    monkeypatch.setattr("app.services.open_route_service.httpx.post", fake_post)
+    
+    payload = {
+        "origin": {
+            "latitude": -5.0892,
+            "longitude": -42.8016
+        },
+        "destination": {
+            "latitude": -5.0920,
+            "longitude": -42.8100
+        }
+    }
+    
+    response = client.post(endpoint, json=payload)
+    
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["distance"] == 1250.5
+    assert data["duration"] == 420.0
+    
+    # Validar que os pontos da rota foram convertidos e retornados no formato esperado
+    assert data["geometry"] == [
+        {"latitude": -5.0892, "longitude": -42.8016},
+        {"latitude": -5.0901, "longitude": -42.8050},
+        {"latitude": -5.0920, "longitude": -42.8100}
+    ]
+    
+    assert len(called) == 1
+


### PR DESCRIPTION
* **Integração com OpenRouteService**: Criado o client `OpenRouteServiceClient` utilizando `httpx` para fazer as requisições à API externa de rotas de forma dinâmica.
* **Gerenciamento de Segredos**: Adicionado suporte à biblioteca `python-dotenv` e configurado o startup em `main.py` para carregar a chave de API `ORS_API_KEY` a partir de um arquivo `.env` local.
* **Atualização do Contrato da API**: Alterada a resposta do endpoint `POST /api/routes/safe` no schema `SafeRouteResponse` e no controller para processar e retornar a distância, a duração estimada e a lista de coordenadas (`geometry`) da rota formatadas.
* **Testes de Integração e Mocks**: Desenvolvido um teste de integração mockando as chamadas HTTP (evitando conexões reais com a internet) e atualizados os testes de sucesso anteriores para validar a nova resposta estruturada.

Como testar:

Para rodar toda a **suíte de testes** (com todos os 22 testes passando):

Estando dentro do ambiente virtual da pasta backend:
`python -m pytest tests/test_safe_route.py -v`

**Teste Manual (API Real)**
Suba a API localmente com o .env configurado e dispare um cURL ou utilize ferramentas como Postman/Insomnia:

- Iniciar a API
`uvicorn app.main:app --reload`
- Disparar chamada via PowerShell usando Invoke-RestMethod ou curl.exe
```
Invoke-RestMethod -Uri "http://127.0.0.1:8000/api/routes/safe" `
                  -Method Post `
                  -Headers @{"Content-Type" = "application/json"} `
                  -Body '{"origin": {"latitude": -5.0892, "longitude": -42.8016}, "destination": {"latitude": -5.0920, "longitude": -42.8100}}'
```