### PR TITLE
feat: criar endpoints mockados de compartilhamento. Closes #93

### DIFF
--- a/backend/app/controllers/mock_sharing_controller.py
+++ b/backend/app/controllers/mock_sharing_controller.py
@@ -1,0 +1,156 @@
+from fastapi import APIRouter, HTTPException, status
+from typing import Any, Dict
+from app.schemas.sharing_schema import (
+    SharingSessionCreateResponse,
+    SharedRouteResponse,
+    UpdateLocationResponse,
+    EndSharingResponse
+)
+from app.repositories.sharing_repository import InMemorySharingRepository
+from app.services.sharing_service import (
+    SharingService,
+    SessionNotFoundError,
+    SessionExpiredError,
+    SessionEndedError
+)
+
+router = APIRouter(tags=["Compartilhamento Mockado"])
+
+_repository = InMemorySharingRepository()
+_sharing_service = SharingService(_repository)
+
+@router.post("/mock/sharing-sessions", response_model=SharingSessionCreateResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/api/mock/sharing-sessions", response_model=SharingSessionCreateResponse, status_code=status.HTTP_201_CREATED)
+def create_sharing_session(payload: Dict[str, Any]):
+    """
+    Inicia uma nova sessão de compartilhamento de trajeto.
+    """
+    # 1. Validação de presença
+    if "currentLocation" not in payload or payload["currentLocation"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="currentLocation is required"
+        )
+    if "destination" not in payload or payload["destination"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="destination is required"
+        )
+
+    current_location = payload["currentLocation"]
+    destination = payload["destination"]
+
+    # 2. Validação do tipo objeto e presença de campos específicos
+    if not isinstance(current_location, dict) or "latitude" not in current_location or "longitude" not in current_location:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="currentLocation must contain latitude and longitude"
+        )
+    if not isinstance(destination, dict) or "latitude" not in destination or "longitude" not in destination:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="destination must contain latitude and longitude"
+        )
+
+    try:
+        session = _sharing_service.create_session(current_location, destination)
+        return {
+            "token": session.token,
+            "shareUrl": f"https://ruasegura.app/shared/{session.token}",
+            "expiresAt": session.expires_at
+        }
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+
+
+@router.get("/mock/shared-routes/{token}", response_model=SharedRouteResponse)
+@router.get("/api/mock/shared-routes/{token}", response_model=SharedRouteResponse)
+def get_shared_route(token: str):
+    """
+    Busca os detalhes de uma sessão de compartilhamento ativa ou encerrada pelo token.
+    """
+    try:
+        session = _sharing_service.get_session(token)
+        return {
+            "status": session.status,
+            "currentLocation": session.current_location,
+            "destination": session.destination,
+            "lastUpdatedAt": session.last_updated_at
+        }
+    except SessionNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )
+    except SessionExpiredError as e:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=str(e)
+        )
+
+
+@router.patch("/mock/sharing-sessions/{token}/location", response_model=UpdateLocationResponse)
+@router.patch("/api/mock/sharing-sessions/{token}/location", response_model=UpdateLocationResponse)
+def update_location(token: str, payload: Dict[str, Any]):
+    """
+    Atualiza a localização atual da sessão pelo token.
+    """
+    if "latitude" not in payload or "longitude" not in payload:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="latitude and longitude are required"
+        )
+
+    try:
+        latitude = payload["latitude"]
+        longitude = payload["longitude"]
+        session = _sharing_service.update_location(token, latitude, longitude)
+        return {
+            "status": session.status,
+            "currentLocation": session.current_location,
+            "lastUpdatedAt": session.last_updated_at
+        }
+    except SessionNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )
+    except SessionExpiredError as e:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=str(e)
+        )
+    except SessionEndedError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(e)
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+
+
+@router.post("/mock/sharing-sessions/{token}/end", response_model=EndSharingResponse)
+@router.post("/api/mock/sharing-sessions/{token}/end", response_model=EndSharingResponse)
+@router.delete("/mock/sharing-sessions/{token}", response_model=EndSharingResponse)
+@router.delete("/api/mock/sharing-sessions/{token}", response_model=EndSharingResponse)
+def end_sharing_session(token: str):
+    """
+    Encerra a sessão de compartilhamento pelo token.
+    """
+    try:
+        session, message = _sharing_service.end_session(token)
+        return {
+            "status": session.status,
+            "message": message
+        }
+    except SessionNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from app.controllers.review_controller import router as review_router
 from app.controllers.risk_controller import router as risk_router
 from app.controllers import alert_controller
 from app.controllers.route_controller import router as route_router
+from app.controllers.mock_sharing_controller import router as mock_sharing_router
 
 app = FastAPI(title="Rua Segura API")
 
@@ -22,6 +23,7 @@ app.include_router(review_router)
 app.include_router(risk_router)
 app.include_router(alert_controller.router)
 app.include_router(route_router)
+app.include_router(mock_sharing_router)
 
 @app.get("/")
 def read_root():

--- a/backend/app/models/sharing_session.py
+++ b/backend/app/models/sharing_session.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+class SharingSession:
+    """
+    Entidade de domínio que representa uma sessão de compartilhamento de trajeto mockado.
+    """
+    def __init__(
+        self,
+        token: str,
+        status: str,
+        current_location: dict,  # {"latitude": float, "longitude": float}
+        destination: dict,       # {"latitude": float, "longitude": float}
+        created_at: datetime,
+        expires_at: datetime,
+        last_updated_at: datetime
+    ):
+        self.token = token
+        self.status = status
+        self.current_location = current_location
+        self.destination = destination
+        self.created_at = created_at
+        self.expires_at = expires_at
+        self.last_updated_at = last_updated_at
+
+    def to_dict(self) -> dict:
+        return {
+            "token": self.token,
+            "status": self.status,
+            "currentLocation": self.current_location,
+            "destination": self.destination,
+            "createdAt": self.created_at.isoformat(),
+            "expiresAt": self.expires_at.isoformat(),
+            "lastUpdatedAt": self.last_updated_at.isoformat()
+        }

--- a/backend/app/repositories/sharing_repository.py
+++ b/backend/app/repositories/sharing_repository.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Optional
+from app.models.sharing_session import SharingSession
+
+class SharingRepository(ABC):
+    """
+    Interface abstrata para persistência de sessões de compartilhamento (SharingSession).
+    """
+    @abstractmethod
+    def save(self, session: SharingSession) -> SharingSession:
+        pass
+
+    @abstractmethod
+    def find_by_token(self, token: str) -> Optional[SharingSession]:
+        pass
+
+class InMemorySharingRepository(SharingRepository):
+    """
+    Implementação em memória do repositório de compartilhamento de trajetos.
+    """
+    def __init__(self):
+        self._sessions: Dict[str, SharingSession] = {}
+
+    def save(self, session: SharingSession) -> SharingSession:
+        self._sessions[session.token] = session
+        return session
+
+    def find_by_token(self, token: str) -> Optional[SharingSession]:
+        return self._sessions.get(token)

--- a/backend/app/schemas/sharing_schema.py
+++ b/backend/app/schemas/sharing_schema.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel, Field
+from datetime import datetime
+
+class CoordinateSchema(BaseModel):
+    latitude: float = Field(..., description="Latitude da coordenada")
+    longitude: float = Field(..., description="Longitude da coordenada")
+
+class SharingSessionCreateRequest(BaseModel):
+    currentLocation: CoordinateSchema = Field(..., description="Localização atual")
+    destination: CoordinateSchema = Field(..., description="Destino do trajeto")
+
+class SharingSessionCreateResponse(BaseModel):
+    token: str = Field(..., description="Token de compartilhamento gerado")
+    shareUrl: str = Field(..., description="URL pública para consultar o trajeto")
+    expiresAt: datetime = Field(..., description="Data/hora de expiração do compartilhamento")
+
+class SharedRouteResponse(BaseModel):
+    status: str = Field(..., description="Status da sessão ('active' ou 'ended')")
+    currentLocation: CoordinateSchema = Field(..., description="Última localização registrada")
+    destination: CoordinateSchema = Field(..., description="Coordenadas de destino")
+    lastUpdatedAt: datetime = Field(..., description="Data/hora da última atualização de localização")
+
+class UpdateLocationRequest(BaseModel):
+    latitude: float = Field(..., description="Latitude atualizada")
+    longitude: float = Field(..., description="Longitude atualizada")
+
+class UpdateLocationResponse(BaseModel):
+    status: str = Field(..., description="Status da sessão")
+    currentLocation: CoordinateSchema = Field(..., description="Localização atualizada")
+    lastUpdatedAt: datetime = Field(..., description="Data/hora da atualização")
+
+class EndSharingResponse(BaseModel):
+    status: str = Field(..., description="Status final da sessão (normalmente 'ended')")
+    message: str = Field(..., description="Mensagem de sucesso/informação")

--- a/backend/app/services/sharing_service.py
+++ b/backend/app/services/sharing_service.py
@@ -1,0 +1,120 @@
+import uuid
+from datetime import datetime, timezone, timedelta
+from typing import Optional, Tuple
+from app.models.sharing_session import SharingSession
+from app.repositories.sharing_repository import SharingRepository
+
+class SessionNotFoundError(Exception):
+    pass
+
+class SessionExpiredError(Exception):
+    pass
+
+class SessionEndedError(Exception):
+    pass
+
+class SharingService:
+    """
+    Serviço que implementa as regras de negócio para a gestão de sessões de compartilhamento de trajeto.
+    """
+    def __init__(self, repository: SharingRepository):
+        self.repository = repository
+
+    def create_session(self, current_location: dict, destination: dict) -> SharingSession:
+        # Validação de latitude/longitude de origem e destino
+        for loc_name, loc in [("currentLocation", current_location), ("destination", destination)]:
+            if not isinstance(loc, dict):
+                raise ValueError(f"Objeto de {loc_name} inválido.")
+            lat = loc.get("latitude")
+            lng = loc.get("longitude")
+            if lat is None or lng is None:
+                raise ValueError(f"Coordenadas de {loc_name} incompletas.")
+            try:
+                f_lat = float(lat)
+                f_lng = float(lng)
+            except (ValueError, TypeError):
+                raise ValueError(f"Coordenadas de {loc_name} devem ser numéricas.")
+            if not (-90.0 <= f_lat <= 90.0):
+                raise ValueError("Latitude must be between -90 and 90")
+            if not (-180.0 <= f_lng <= 180.0):
+                raise ValueError("Longitude must be between -180 and 180")
+
+        token = uuid.uuid4().hex[:8]
+        now = datetime.now(timezone.utc)
+        expires_at = now + timedelta(minutes=60)
+
+        session = SharingSession(
+            token=token,
+            status="active",
+            current_location={
+                "latitude": float(current_location["latitude"]),
+                "longitude": float(current_location["longitude"])
+            },
+            destination={
+                "latitude": float(destination["latitude"]),
+                "longitude": float(destination["longitude"])
+            },
+            created_at=now,
+            expires_at=expires_at,
+            last_updated_at=now
+        )
+        return self.repository.save(session)
+
+    def get_session(self, token: str) -> SharingSession:
+        if not token:
+            raise ValueError("O token é obrigatório.")
+        session = self.repository.find_by_token(token)
+        if not session:
+            raise SessionNotFoundError("Sessão de compartilhamento não encontrada.")
+        
+        # Verifica se expirou
+        if datetime.now(timezone.utc) > session.expires_at:
+            raise SessionExpiredError("Sessão de compartilhamento expirada.")
+            
+        return session
+
+    def update_location(self, token: str, latitude: float, longitude: float) -> SharingSession:
+        if not token:
+            raise ValueError("O token é obrigatório.")
+        
+        # Validação geográfica
+        try:
+            f_lat = float(latitude)
+            f_lng = float(longitude)
+        except (ValueError, TypeError):
+            raise ValueError("As coordenadas devem ser numéricas.")
+            
+        if not (-90.0 <= f_lat <= 90.0):
+            raise ValueError("Latitude must be between -90 and 90")
+        if not (-180.0 <= f_lng <= 180.0):
+            raise ValueError("Longitude must be between -180 and 180")
+
+        session = self.repository.find_by_token(token)
+        if not session:
+            raise SessionNotFoundError("Sessão de compartilhamento não encontrada.")
+
+        # Verifica se expirou
+        if datetime.now(timezone.utc) > session.expires_at:
+            raise SessionExpiredError("Sessão de compartilhamento expirada.")
+
+        # Verifica se já encerrou
+        if session.status == "ended":
+            raise SessionEndedError("Compartilhamento encerrado. Não é possível atualizar a localização.")
+
+        session.current_location = {"latitude": f_lat, "longitude": f_lng}
+        session.last_updated_at = datetime.now(timezone.utc)
+        return self.repository.save(session)
+
+    def end_session(self, token: str) -> Tuple[SharingSession, str]:
+        if not token:
+            raise ValueError("O token é obrigatório.")
+            
+        session = self.repository.find_by_token(token)
+        if not session:
+            raise SessionNotFoundError("Sessão de compartilhamento não encontrada.")
+            
+        if session.status == "ended":
+            return session, "Compartilhamento já está encerrado."
+
+        session.status = "ended"
+        return self.repository.save(session), "Compartilhamento encerrado com sucesso."

--- a/backend/tests/test_mock_sharing.py
+++ b/backend/tests/test_mock_sharing.py
@@ -1,0 +1,197 @@
+import unittest
+from datetime import datetime, timezone, timedelta
+from fastapi.testclient import TestClient
+from app.main import app
+from app.controllers.mock_sharing_controller import _repository, _sharing_service
+
+class TestMockSharingEndpoints(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        # Limpar o repositório em memória antes de cada teste
+        _repository._sessions.clear()
+
+    def test_create_session_success(self):
+        payload = {
+            "currentLocation": {
+                "latitude": -5.0892,
+                "longitude": -42.8016
+            },
+            "destination": {
+                "latitude": -5.0911,
+                "longitude": -42.8033
+            }
+        }
+        # Testar tanto rota com /api quanto sem
+        for route in ["/mock/sharing-sessions", "/api/mock/sharing-sessions"]:
+            response = self.client.post(route, json=payload)
+            self.assertEqual(response.status_code, 201)
+            
+            data = response.json()
+            self.assertIn("token", data)
+            self.assertIn("shareUrl", data)
+            self.assertIn("expiresAt", data)
+            self.assertTrue(data["shareUrl"].endswith(data["token"]))
+            
+            # Verificar se está no repositório
+            token = data["token"]
+            session = _repository.find_by_token(token)
+            self.assertIsNotNone(session)
+            self.assertEqual(session.status, "active")
+
+    def test_get_active_session(self):
+        # 1. Cria a sessão via serviço
+        session = _sharing_service.create_session(
+            current_location={"latitude": -5.0892, "longitude": -42.8016},
+            destination={"latitude": -5.0911, "longitude": -42.8033}
+        )
+        
+        # 2. Consulta via endpoint
+        for route in [f"/mock/shared-routes/{session.token}", f"/api/mock/shared-routes/{session.token}"]:
+            response = self.client.get(route)
+            self.assertEqual(response.status_code, 200)
+            
+            data = response.json()
+            self.assertEqual(data["status"], "active")
+            self.assertEqual(data["currentLocation"]["latitude"], -5.0892)
+            self.assertEqual(data["currentLocation"]["longitude"], -42.8016)
+            self.assertEqual(data["destination"]["latitude"], -5.0911)
+            self.assertEqual(data["destination"]["longitude"], -42.8033)
+            self.assertIn("lastUpdatedAt", data)
+
+    def test_get_session_not_found(self):
+        response = self.client.get("/mock/shared-routes/nonexistenttoken")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["detail"], "Sessão de compartilhamento não encontrada.")
+
+    def test_update_location_success(self):
+        session = _sharing_service.create_session(
+            current_location={"latitude": -5.0892, "longitude": -42.8016},
+            destination={"latitude": -5.0911, "longitude": -42.8033}
+        )
+        
+        update_payload = {
+            "latitude": -5.0900,
+            "longitude": -42.8020
+        }
+        
+        # Atualiza a localização
+        response = self.client.patch(f"/mock/sharing-sessions/{session.token}/location", json=update_payload)
+        self.assertEqual(response.status_code, 200)
+        
+        data = response.json()
+        self.assertEqual(data["status"], "active")
+        self.assertEqual(data["currentLocation"]["latitude"], -5.0900)
+        self.assertEqual(data["currentLocation"]["longitude"], -42.8020)
+        self.assertIn("lastUpdatedAt", data)
+        
+        # Consultar novamente para confirmar persistência
+        get_response = self.client.get(f"/mock/shared-routes/{session.token}")
+        get_data = get_response.json()
+        self.assertEqual(get_data["currentLocation"]["latitude"], -5.0900)
+        self.assertEqual(get_data["destination"]["latitude"], -5.0911) # Mantido igual
+
+    def test_update_location_not_found(self):
+        response = self.client.patch("/mock/sharing-sessions/invalidtoken/location", json={"latitude": 0.0, "longitude": 0.0})
+        self.assertEqual(response.status_code, 404)
+
+    def test_end_session_success(self):
+        session = _sharing_service.create_session(
+            current_location={"latitude": -5.0892, "longitude": -42.8016},
+            destination={"latitude": -5.0911, "longitude": -42.8033}
+        )
+        
+        # Encerra a sessão via POST .../end
+        response = self.client.post(f"/mock/sharing-sessions/{session.token}/end")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ended")
+        self.assertEqual(response.json()["message"], "Compartilhamento encerrado com sucesso.")
+        
+        # Consulta novamente para verificar o status ended
+        get_response = self.client.get(f"/mock/shared-routes/{session.token}")
+        self.assertEqual(get_response.json()["status"], "ended")
+
+    def test_end_session_via_delete(self):
+        session = _sharing_service.create_session(
+            current_location={"latitude": -5.0892, "longitude": -42.8016},
+            destination={"latitude": -5.0911, "longitude": -42.8033}
+        )
+        
+        # Encerra a sessão via DELETE
+        response = self.client.delete(f"/mock/sharing-sessions/{session.token}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ended")
+        
+        # Tenta encerrar novamente, deve retornar mensagem que já está encerrado
+        response2 = self.client.delete(f"/mock/sharing-sessions/{session.token}")
+        self.assertEqual(response2.json()["message"], "Compartilhamento já está encerrado.")
+
+    def test_update_location_ended_session(self):
+        session = _sharing_service.create_session(
+            current_location={"latitude": -5.0892, "longitude": -42.8016},
+            destination={"latitude": -5.0911, "longitude": -42.8033}
+        )
+        
+        # Encerra a sessão
+        _sharing_service.end_session(session.token)
+        
+        # Tenta atualizar
+        response = self.client.patch(
+            f"/mock/sharing-sessions/{session.token}/location",
+            json={"latitude": -5.0900, "longitude": -42.8020}
+        )
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["detail"], "Compartilhamento encerrado. Não é possível atualizar a localização.")
+
+    def test_invalid_coordinates(self):
+        # 1. Criação com latitude inválida
+        payload = {
+            "currentLocation": {"latitude": 95.0, "longitude": -42.8016},
+            "destination": {"latitude": -5.0911, "longitude": -42.8033}
+        }
+        response = self.client.post("/mock/sharing-sessions", json=payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], "Latitude must be between -90 and 90")
+
+        # 2. Criação com longitude inválida
+        payload = {
+            "currentLocation": {"latitude": -5.0892, "longitude": -190.0},
+            "destination": {"latitude": -5.0911, "longitude": -42.8033}
+        }
+        response = self.client.post("/mock/sharing-sessions", json=payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], "Longitude must be between -180 and 180")
+
+        # 3. Atualização com latitude inválida
+        session = _sharing_service.create_session(
+            current_location={"latitude": -5.0892, "longitude": -42.8016},
+            destination={"latitude": -5.0911, "longitude": -42.8033}
+        )
+        response = self.client.patch(
+            f"/mock/sharing-sessions/{session.token}/location",
+            json={"latitude": -95.0, "longitude": -42.8020}
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], "Latitude must be between -90 and 90")
+
+    def test_expired_session(self):
+        session = _sharing_service.create_session(
+            current_location={"latitude": -5.0892, "longitude": -42.8016},
+            destination={"latitude": -5.0911, "longitude": -42.8033}
+        )
+        
+        # Simula expiração alterando expires_at para o passado
+        session.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        _repository.save(session)
+        
+        # Consulta deve retornar 410 Gone
+        get_response = self.client.get(f"/mock/shared-routes/{session.token}")
+        self.assertEqual(get_response.status_code, 410)
+        self.assertEqual(get_response.json()["detail"], "Sessão de compartilhamento expirada.")
+        
+        # Atualização deve retornar 410 Gone
+        patch_response = self.client.patch(
+            f"/mock/sharing-sessions/{session.token}/location",
+            json={"latitude": -5.0900, "longitude": -42.8020}
+        )
+        self.assertEqual(patch_response.status_code, 410)
+        self.assertEqual(patch_response.json()["detail"], "Sessão de compartilhamento expirada.")


### PR DESCRIPTION
Foi criada a base mockada (simulada) do fluxo de compartilhamento de trajetos no backend do projeto Rua Segura. O objetivo foi fornecer uma API funcional em memória para que a equipe de frontend possa iniciar a integração da funcionalidade sem depender de um banco de dados real ou GPS. Toda a implementação foi estruturada seguindo o padrão arquitetural já estabelecido do projeto (FastAPI).

