### PR TITLE
feat: Criar compartilhamento temporário em memória. Closes #92

### DIFF
--- a/backend/app/controllers/mock_sharing_controller.py
+++ b/backend/app/controllers/mock_sharing_controller.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException, status
 from typing import Any, Dict
+
 from app.schemas.sharing_schema import (
     SharingSessionCreateResponse,
     SharedRouteResponse,
@@ -14,23 +15,34 @@ from app.services.sharing_service import (
     SessionEndedError
 )
 
+
 router = APIRouter(tags=["Compartilhamento Mockado"])
 
 _repository = InMemorySharingRepository()
 _sharing_service = SharingService(_repository)
 
-@router.post("/mock/sharing-sessions", response_model=SharingSessionCreateResponse, status_code=status.HTTP_201_CREATED)
-@router.post("/api/mock/sharing-sessions", response_model=SharingSessionCreateResponse, status_code=status.HTTP_201_CREATED)
+
+@router.post(
+    "/mock/sharing-sessions",
+    response_model=SharingSessionCreateResponse,
+    status_code=status.HTTP_201_CREATED
+)
+@router.post(
+    "/api/mock/sharing-sessions",
+    response_model=SharingSessionCreateResponse,
+    status_code=status.HTTP_201_CREATED
+)
 def create_sharing_session(payload: Dict[str, Any]):
     """
     Inicia uma nova sessão de compartilhamento de trajeto.
     """
-    # 1. Validação de presença
+
     if "currentLocation" not in payload or payload["currentLocation"] is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="currentLocation is required"
         )
+
     if "destination" not in payload or payload["destination"] is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -39,13 +51,14 @@ def create_sharing_session(payload: Dict[str, Any]):
 
     current_location = payload["currentLocation"]
     destination = payload["destination"]
+    origin = payload.get("origin", current_location)
 
-    # 2. Validação do tipo objeto e presença de campos específicos
     if not isinstance(current_location, dict) or "latitude" not in current_location or "longitude" not in current_location:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="currentLocation must contain latitude and longitude"
         )
+
     if not isinstance(destination, dict) or "latitude" not in destination or "longitude" not in destination:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -53,12 +66,18 @@ def create_sharing_session(payload: Dict[str, Any]):
         )
 
     try:
-        session = _sharing_service.create_session(current_location, destination)
+        session = _sharing_service.create_session(
+            current_location=current_location,
+            destination=destination,
+            origin=origin
+        )
+
         return {
             "token": session.token,
             "shareUrl": f"https://ruasegura.app/shared/{session.token}",
             "expiresAt": session.expires_at
         }
+
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -72,19 +91,24 @@ def get_shared_route(token: str):
     """
     Busca os detalhes de uma sessão de compartilhamento ativa ou encerrada pelo token.
     """
+
     try:
         session = _sharing_service.get_session(token)
+
         return {
             "status": session.status,
+            "origin": session.origin,
             "currentLocation": session.current_location,
             "destination": session.destination,
             "lastUpdatedAt": session.last_updated_at
         }
+
     except SessionNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e)
         )
+
     except SessionExpiredError as e:
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
@@ -92,12 +116,19 @@ def get_shared_route(token: str):
         )
 
 
-@router.patch("/mock/sharing-sessions/{token}/location", response_model=UpdateLocationResponse)
-@router.patch("/api/mock/sharing-sessions/{token}/location", response_model=UpdateLocationResponse)
+@router.patch(
+    "/mock/sharing-sessions/{token}/location",
+    response_model=UpdateLocationResponse
+)
+@router.patch(
+    "/api/mock/sharing-sessions/{token}/location",
+    response_model=UpdateLocationResponse
+)
 def update_location(token: str, payload: Dict[str, Any]):
     """
     Atualiza a localização atual da sessão pelo token.
     """
+
     if "latitude" not in payload or "longitude" not in payload:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -107,27 +138,33 @@ def update_location(token: str, payload: Dict[str, Any]):
     try:
         latitude = payload["latitude"]
         longitude = payload["longitude"]
+
         session = _sharing_service.update_location(token, latitude, longitude)
+
         return {
             "status": session.status,
             "currentLocation": session.current_location,
             "lastUpdatedAt": session.last_updated_at
         }
+
     except SessionNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e)
         )
+
     except SessionExpiredError as e:
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
             detail=str(e)
         )
+
     except SessionEndedError as e:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(e)
         )
+
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -135,20 +172,35 @@ def update_location(token: str, payload: Dict[str, Any]):
         )
 
 
-@router.post("/mock/sharing-sessions/{token}/end", response_model=EndSharingResponse)
-@router.post("/api/mock/sharing-sessions/{token}/end", response_model=EndSharingResponse)
-@router.delete("/mock/sharing-sessions/{token}", response_model=EndSharingResponse)
-@router.delete("/api/mock/sharing-sessions/{token}", response_model=EndSharingResponse)
+@router.post(
+    "/mock/sharing-sessions/{token}/end",
+    response_model=EndSharingResponse
+)
+@router.post(
+    "/api/mock/sharing-sessions/{token}/end",
+    response_model=EndSharingResponse
+)
+@router.delete(
+    "/mock/sharing-sessions/{token}",
+    response_model=EndSharingResponse
+)
+@router.delete(
+    "/api/mock/sharing-sessions/{token}",
+    response_model=EndSharingResponse
+)
 def end_sharing_session(token: str):
     """
     Encerra a sessão de compartilhamento pelo token.
     """
+
     try:
         session, message = _sharing_service.end_session(token)
+
         return {
             "status": session.status,
             "message": message
         }
+
     except SessionNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/models/sharing_session.py
+++ b/backend/app/models/sharing_session.py
@@ -1,21 +1,25 @@
 from datetime import datetime
 
+
 class SharingSession:
     """
     Entidade de domínio que representa uma sessão de compartilhamento de trajeto mockado.
     """
+
     def __init__(
         self,
         token: str,
         status: str,
-        current_location: dict,  # {"latitude": float, "longitude": float}
-        destination: dict,       # {"latitude": float, "longitude": float}
+        origin: dict,
+        current_location: dict,
+        destination: dict,
         created_at: datetime,
         expires_at: datetime,
         last_updated_at: datetime
     ):
         self.token = token
         self.status = status
+        self.origin = origin
         self.current_location = current_location
         self.destination = destination
         self.created_at = created_at
@@ -26,6 +30,7 @@ class SharingSession:
         return {
             "token": self.token,
             "status": self.status,
+            "origin": self.origin,
             "currentLocation": self.current_location,
             "destination": self.destination,
             "createdAt": self.created_at.isoformat(),

--- a/backend/app/schemas/sharing_schema.py
+++ b/backend/app/schemas/sharing_schema.py
@@ -1,34 +1,47 @@
-from pydantic import BaseModel, Field
 from datetime import datetime
+
+from pydantic import BaseModel, Field
+
 
 class CoordinateSchema(BaseModel):
     latitude: float = Field(..., description="Latitude da coordenada")
     longitude: float = Field(..., description="Longitude da coordenada")
 
+
 class SharingSessionCreateRequest(BaseModel):
+    origin: CoordinateSchema | None = Field(
+        default=None,
+        description="Origem da rota"
+    )
     currentLocation: CoordinateSchema = Field(..., description="Localização atual")
     destination: CoordinateSchema = Field(..., description="Destino do trajeto")
+
 
 class SharingSessionCreateResponse(BaseModel):
     token: str = Field(..., description="Token de compartilhamento gerado")
     shareUrl: str = Field(..., description="URL pública para consultar o trajeto")
     expiresAt: datetime = Field(..., description="Data/hora de expiração do compartilhamento")
 
+
 class SharedRouteResponse(BaseModel):
-    status: str = Field(..., description="Status da sessão ('active' ou 'ended')")
+    status: str = Field(..., description="Status da sessão")
+    origin: CoordinateSchema = Field(..., description="Origem da rota")
     currentLocation: CoordinateSchema = Field(..., description="Última localização registrada")
     destination: CoordinateSchema = Field(..., description="Coordenadas de destino")
     lastUpdatedAt: datetime = Field(..., description="Data/hora da última atualização de localização")
 
+
 class UpdateLocationRequest(BaseModel):
     latitude: float = Field(..., description="Latitude atualizada")
     longitude: float = Field(..., description="Longitude atualizada")
+
 
 class UpdateLocationResponse(BaseModel):
     status: str = Field(..., description="Status da sessão")
     currentLocation: CoordinateSchema = Field(..., description="Localização atualizada")
     lastUpdatedAt: datetime = Field(..., description="Data/hora da atualização")
 
+
 class EndSharingResponse(BaseModel):
-    status: str = Field(..., description="Status final da sessão (normalmente 'ended')")
+    status: str = Field(..., description="Status final da sessão")
     message: str = Field(..., description="Mensagem de sucesso/informação")

--- a/backend/app/services/sharing_service.py
+++ b/backend/app/services/sharing_service.py
@@ -34,31 +34,9 @@ class SharingService:
     ) -> SharingSession:
         origin = origin or current_location
 
-        for loc_name, loc in [
-            ("origin", origin),
-            ("currentLocation", current_location),
-            ("destination", destination)
-        ]:
-            if not isinstance(loc, dict):
-                raise ValueError(f"Objeto de {loc_name} inválido.")
-
-            lat = loc.get("latitude")
-            lng = loc.get("longitude")
-
-            if lat is None or lng is None:
-                raise ValueError(f"Coordenadas de {loc_name} incompletas.")
-
-            try:
-                f_lat = float(lat)
-                f_lng = float(lng)
-            except (ValueError, TypeError):
-                raise ValueError(f"Coordenadas de {loc_name} devem ser numéricas.")
-
-            if not (-90.0 <= f_lat <= 90.0):
-                raise ValueError("Latitude must be between -90 and 90")
-
-            if not (-180.0 <= f_lng <= 180.0):
-                raise ValueError("Longitude must be between -180 and 180")
+        validated_origin = self._validate_location("origin", origin)
+        validated_current_location = self._validate_location("currentLocation", current_location)
+        validated_destination = self._validate_location("destination", destination)
 
         token = uuid.uuid4().hex[:8]
         now = datetime.now(timezone.utc)
@@ -67,18 +45,9 @@ class SharingService:
         session = SharingSession(
             token=token,
             status="active",
-            origin={
-                "latitude": float(origin["latitude"]),
-                "longitude": float(origin["longitude"])
-            },
-            current_location={
-                "latitude": float(current_location["latitude"]),
-                "longitude": float(current_location["longitude"])
-            },
-            destination={
-                "latitude": float(destination["latitude"]),
-                "longitude": float(destination["longitude"])
-            },
+            origin=validated_origin,
+            current_location=validated_current_location,
+            destination=validated_destination,
             created_at=now,
             expires_at=expires_at,
             last_updated_at=now
@@ -106,17 +75,13 @@ class SharingService:
         if not token:
             raise ValueError("O token é obrigatório.")
 
-        try:
-            f_lat = float(latitude)
-            f_lng = float(longitude)
-        except (ValueError, TypeError):
-            raise ValueError("As coordenadas devem ser numéricas.")
-
-        if not (-90.0 <= f_lat <= 90.0):
-            raise ValueError("Latitude must be between -90 and 90")
-
-        if not (-180.0 <= f_lng <= 180.0):
-            raise ValueError("Longitude must be between -180 and 180")
+        validated_location = self._validate_location(
+            "currentLocation",
+            {
+                "latitude": latitude,
+                "longitude": longitude
+            }
+        )
 
         session = self.repository.find_by_token(token)
 
@@ -131,10 +96,7 @@ class SharingService:
         if session.status == "ended":
             raise SessionEndedError("Compartilhamento encerrado. Não é possível atualizar a localização.")
 
-        session.current_location = {
-            "latitude": f_lat,
-            "longitude": f_lng
-        }
+        session.current_location = validated_location
         session.last_updated_at = datetime.now(timezone.utc)
 
         return self.repository.save(session)
@@ -154,3 +116,30 @@ class SharingService:
         session.status = "ended"
 
         return self.repository.save(session), "Compartilhamento encerrado com sucesso."
+
+    def _validate_location(self, loc_name: str, loc: dict) -> dict:
+        if not isinstance(loc, dict):
+            raise ValueError(f"Objeto de {loc_name} inválido.")
+
+        latitude = loc.get("latitude")
+        longitude = loc.get("longitude")
+
+        if latitude is None or longitude is None:
+            raise ValueError(f"Coordenadas de {loc_name} incompletas.")
+
+        try:
+            validated_latitude = float(latitude)
+            validated_longitude = float(longitude)
+        except (ValueError, TypeError):
+            raise ValueError(f"Coordenadas de {loc_name} devem ser numéricas.")
+
+        if not (-90.0 <= validated_latitude <= 90.0):
+            raise ValueError("Latitude must be between -90 and 90")
+
+        if not (-180.0 <= validated_longitude <= 180.0):
+            raise ValueError("Longitude must be between -180 and 180")
+
+        return {
+            "latitude": validated_latitude,
+            "longitude": validated_longitude
+        }

--- a/backend/app/services/sharing_service.py
+++ b/backend/app/services/sharing_service.py
@@ -1,41 +1,62 @@
 import uuid
 from datetime import datetime, timezone, timedelta
 from typing import Optional, Tuple
+
 from app.models.sharing_session import SharingSession
 from app.repositories.sharing_repository import SharingRepository
+
 
 class SessionNotFoundError(Exception):
     pass
 
+
 class SessionExpiredError(Exception):
     pass
 
+
 class SessionEndedError(Exception):
     pass
+
 
 class SharingService:
     """
     Serviço que implementa as regras de negócio para a gestão de sessões de compartilhamento de trajeto.
     """
+
     def __init__(self, repository: SharingRepository):
         self.repository = repository
 
-    def create_session(self, current_location: dict, destination: dict) -> SharingSession:
-        # Validação de latitude/longitude de origem e destino
-        for loc_name, loc in [("currentLocation", current_location), ("destination", destination)]:
+    def create_session(
+        self,
+        current_location: dict,
+        destination: dict,
+        origin: Optional[dict] = None
+    ) -> SharingSession:
+        origin = origin or current_location
+
+        for loc_name, loc in [
+            ("origin", origin),
+            ("currentLocation", current_location),
+            ("destination", destination)
+        ]:
             if not isinstance(loc, dict):
                 raise ValueError(f"Objeto de {loc_name} inválido.")
+
             lat = loc.get("latitude")
             lng = loc.get("longitude")
+
             if lat is None or lng is None:
                 raise ValueError(f"Coordenadas de {loc_name} incompletas.")
+
             try:
                 f_lat = float(lat)
                 f_lng = float(lng)
             except (ValueError, TypeError):
                 raise ValueError(f"Coordenadas de {loc_name} devem ser numéricas.")
+
             if not (-90.0 <= f_lat <= 90.0):
                 raise ValueError("Latitude must be between -90 and 90")
+
             if not (-180.0 <= f_lng <= 180.0):
                 raise ValueError("Longitude must be between -180 and 180")
 
@@ -46,6 +67,10 @@ class SharingService:
         session = SharingSession(
             token=token,
             status="active",
+            origin={
+                "latitude": float(origin["latitude"]),
+                "longitude": float(origin["longitude"])
+            },
             current_location={
                 "latitude": float(current_location["latitude"]),
                 "longitude": float(current_location["longitude"])
@@ -58,63 +83,74 @@ class SharingService:
             expires_at=expires_at,
             last_updated_at=now
         )
+
         return self.repository.save(session)
 
     def get_session(self, token: str) -> SharingSession:
         if not token:
             raise ValueError("O token é obrigatório.")
+
         session = self.repository.find_by_token(token)
+
         if not session:
             raise SessionNotFoundError("Sessão de compartilhamento não encontrada.")
-        
-        # Verifica se expirou
+
         if datetime.now(timezone.utc) > session.expires_at:
+            session.status = "expired"
+            self.repository.save(session)
             raise SessionExpiredError("Sessão de compartilhamento expirada.")
-            
+
         return session
 
     def update_location(self, token: str, latitude: float, longitude: float) -> SharingSession:
         if not token:
             raise ValueError("O token é obrigatório.")
-        
-        # Validação geográfica
+
         try:
             f_lat = float(latitude)
             f_lng = float(longitude)
         except (ValueError, TypeError):
             raise ValueError("As coordenadas devem ser numéricas.")
-            
+
         if not (-90.0 <= f_lat <= 90.0):
             raise ValueError("Latitude must be between -90 and 90")
+
         if not (-180.0 <= f_lng <= 180.0):
             raise ValueError("Longitude must be between -180 and 180")
 
         session = self.repository.find_by_token(token)
+
         if not session:
             raise SessionNotFoundError("Sessão de compartilhamento não encontrada.")
 
-        # Verifica se expirou
         if datetime.now(timezone.utc) > session.expires_at:
+            session.status = "expired"
+            self.repository.save(session)
             raise SessionExpiredError("Sessão de compartilhamento expirada.")
 
-        # Verifica se já encerrou
         if session.status == "ended":
             raise SessionEndedError("Compartilhamento encerrado. Não é possível atualizar a localização.")
 
-        session.current_location = {"latitude": f_lat, "longitude": f_lng}
+        session.current_location = {
+            "latitude": f_lat,
+            "longitude": f_lng
+        }
         session.last_updated_at = datetime.now(timezone.utc)
+
         return self.repository.save(session)
 
     def end_session(self, token: str) -> Tuple[SharingSession, str]:
         if not token:
             raise ValueError("O token é obrigatório.")
-            
+
         session = self.repository.find_by_token(token)
+
         if not session:
             raise SessionNotFoundError("Sessão de compartilhamento não encontrada.")
-            
+
         if session.status == "ended":
             return session, "Compartilhamento já está encerrado."
 
         session.status = "ended"
+
         return self.repository.save(session), "Compartilhamento encerrado com sucesso."

--- a/backend/tests/test_mock_sharing.py
+++ b/backend/tests/test_mock_sharing.py
@@ -195,3 +195,48 @@ class TestMockSharingEndpoints(unittest.TestCase):
         )
         self.assertEqual(patch_response.status_code, 410)
         self.assertEqual(patch_response.json()["detail"], "Sessão de compartilhamento expirada.")
+
+    def test_create_session_with_origin(self):
+        payload = {
+            "origin": {
+                "latitude": -5.0880,
+                "longitude": -42.8000
+            },
+            "currentLocation": {
+                "latitude": -5.0892,
+                "longitude": -42.8016
+            },
+            "destination": {
+                "latitude": -5.0911,
+                "longitude": -42.8033
+            }
+        }
+
+        response = self.client.post("/mock/sharing-sessions", json=payload)
+
+        self.assertEqual(response.status_code, 201)
+
+        data = response.json()
+        token = data["token"]
+
+        session = _repository.find_by_token(token)
+
+        self.assertIsNotNone(session)
+        self.assertEqual(session.origin["latitude"], -5.0880)
+        self.assertEqual(session.origin["longitude"], -42.8000)
+
+    def test_expired_session_should_update_status_to_expired(self):
+        session = _sharing_service.create_session(
+            current_location={"latitude": -5.0892, "longitude": -42.8016},
+            destination={"latitude": -5.0911, "longitude": -42.8033}
+        )
+
+        session.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        _repository.save(session)
+
+        response = self.client.get(f"/mock/shared-routes/{session.token}")
+
+        self.assertEqual(response.status_code, 410)
+
+        expired_session = _repository.find_by_token(session.token)
+        self.assertEqual(expired_session.status, "expired")


### PR DESCRIPTION
## O que foi feito

Complementa o compartilhamento temporário em memória utilizando TDD.

Foram adicionados testes para validar a origem da rota e o status de sessão expirada. A sessão agora armazena origin, currentLocation e destination, além de atualizar o status para "expired" quando o tempo de expiração é atingido. Também foi ajustada a resposta da rota compartilhada e centralizada a validação de coordenadas no service.

## Issue

Closes #92 