### PR TITLE
feat: Calcular risco da rota com base nas ocorrências próximas. Closes #89

### DIFF
--- a/backend/app/services/risk_service.py
+++ b/backend/app/services/risk_service.py
@@ -68,7 +68,19 @@ class RiskService:
         nearby_reviews = []
         nearby_occurrences_data = []
 
-        for review in all_reviews:
+         # Converte o raio de busca de metros para graus decimais (aprox. 111.111 metros por grau)
+        deg_offset = radius_meters / 111111.0
+        # Encontra a Bounding Box da rota inteira
+        latitudes = [pt[0] for pt in route_points]
+        longitudes = [pt[1] for pt in route_points]
+        min_lat, max_lat = min(latitudes) - deg_offset, max(latitudes) + deg_offset
+        min_lng, max_lng = min(longitudes) - deg_offset, max(longitudes) + deg_offset
+        # Pré-filtra as ocorrências de forma rápida antes de calcular a distância ponto-a-segmento
+        relevant_reviews = [
+            review for review in all_reviews
+            if min_lat <= review.latitude <= max_lat and min_lng <= review.longitude <= max_lng
+        ]
+        for review in relevant_reviews:
             min_dist = float("inf")
             if len(route_points) == 0:
                 continue
@@ -87,6 +99,8 @@ class RiskService:
                         min_dist = dist
 
             if min_dist <= radius_meters:
+                # Injeta dinamicamente a distância para que a estratégia possa usar no cálculo
+                review.distance_from_route = min_dist
                 nearby_reviews.append(review)
                 try:
                     occ_id = int(review.id)

--- a/backend/app/services/risk_strategy.py
+++ b/backend/app/services/risk_strategy.py
@@ -1,3 +1,5 @@
+import math
+from datetime import datetime, timezone
 from abc import ABC, abstractmethod
 from typing import List, Tuple
 from app.models.location_review import LocationReview
@@ -22,27 +24,49 @@ class RiskCalculationStrategy(ABC):
         pass
 
 class HeuristicRiskStrategy(RiskCalculationStrategy):
-    """Implementação da estratégia heurística baseada em pesos estáticos"""
+    """Implementação da estratégia heurística baseada em pesos estáticos com decaimento espacial/temporal"""
     def calculate(self, data: List[LocationReview]) -> Tuple[str, int]:
-        score = 0
+        score = 0.0
+        radius_meters = 100.0 # Raio de busca padrão de 100 metros
+        
         for review in data:
+            # 1. Busca o peso base pela gravidade da ocorrência
             weight = 1
             for cat_enum, w in SEVERITY_WEIGHTS.items():
                 if cat_enum.value == review.category:
                     weight = w
                     break
-            score += weight
+            
+            # 2. FATOR DE DECAIMENTO POR DISTÂNCIA
+            distance = getattr(review, "distance_from_route", 0.0)
+            distance_decay = 1.0 - (distance / radius_meters)
+            distance_decay = max(0.0, min(1.0, distance_decay)) # Limita entre 0.0 e 1.0
 
-        # Aplicação dos limiares de classificação definidos no plano
-        # TODO: Mudar limiares teste depois
-        if score < 5:
+            # 3. FATOR DE DECAIMENTO TEMPORAL (MEIA-VIDA)
+            review_time = review.timestamp.astimezone(timezone.utc) if review.timestamp.tzinfo else review.timestamp.replace(tzinfo=timezone.utc)
+            time_diff = datetime.now(timezone.utc) - review_time
+            days_passed = max(0.0, time_diff.total_seconds() / 86400.0)
+
+            # Meia-vida de 30 dias (o peso cai pela metade após 30 dias de registro)
+            lambda_decay = 0.0231  # math.log(2) / 30
+            time_decay = math.exp(-lambda_decay * days_passed)
+
+            # 4. APLICAÇÃO DOS DECAIMENTOS NO PESO EFETIVO
+            effective_weight = weight * distance_decay * time_decay
+            score += effective_weight
+
+        # Arredonda a pontuação acumulada final para o inteiro mais próximo
+        final_score = int(round(score))
+
+        # Aplicação dos limiares de classificação
+        if final_score < 5:
             level = "AZUL"
-        elif 5 <= score < 15:
+        elif 5 <= final_score < 15:
             level = "AMARELO"
         else:
             level = "VERMELHO"
 
-        return level, score
+        return level, final_score
 
 class TimeBasedRiskStrategy(RiskCalculationStrategy):
     """Futura implementação da estratégia baseada em horário do dia"""

--- a/backend/tests/test_risk_decay.py
+++ b/backend/tests/test_risk_decay.py
@@ -1,0 +1,103 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+from app.models.location_review import LocationReview
+from app.services.risk_strategy import HeuristicRiskStrategy
+
+def test_heuristic_strategy_spatial_decay():
+    """Valida se ocorrências mais distantes têm seu risco atenuado corretamente"""
+    strategy = HeuristicRiskStrategy()
+    
+    # 1. Distância = 0 metros (Sem atenuação)
+    # Assalto tem peso base 3. Peso efetivo = 3 * 1.0 = 3
+    review_on_route = LocationReview(
+        id="1",
+        category="Assalto",
+        description="Assalto na rota",
+        latitude=-5.0870,
+        longitude=-42.8080,
+        timestamp=datetime.now(timezone.utc)
+    )
+    review_on_route.distance_from_route = 0.0
+    
+    _, score_on = strategy.calculate([review_on_route])
+    assert score_on == 3
+    
+    # 2. Distância = 50 metros (Meio caminho do raio de 100m, decaimento de 50%)
+    # Peso efetivo = 3 * (1.0 - 50/100) = 1.5. Arredondado = 2
+    review_mid_route = LocationReview(
+        id="2",
+        category="Assalto",
+        description="Assalto a 50m",
+        latitude=-5.0870,
+        longitude=-42.8080,
+        timestamp=datetime.now(timezone.utc)
+    )
+    review_mid_route.distance_from_route = 50.0
+    
+    _, score_mid = strategy.calculate([review_mid_route])
+    assert score_mid == 2
+    
+    # 3. Distância = 90 metros (Decaimento de 90%)
+    # Peso efetivo = 3 * (1.0 - 90/100) = 0.3. Arredondado = 0
+    review_far_route = LocationReview(
+        id="3",
+        category="Assalto",
+        description="Assalto a 90m",
+        latitude=-5.0870,
+        longitude=-42.8080,
+        timestamp=datetime.now(timezone.utc)
+    )
+    review_far_route.distance_from_route = 90.0
+    
+    _, score_far = strategy.calculate([review_far_route])
+    assert score_far == 0
+
+
+def test_heuristic_strategy_temporal_decay():
+    """Valida se ocorrências mais antigas têm seu risco atenuado com o passar do tempo"""
+    strategy = HeuristicRiskStrategy()
+    
+    # 1. Registro recente (0 dias) -> Sem atenuação temporal
+    # Assalto tem peso base 3. Peso efetivo = 3
+    review_recent = LocationReview(
+        id="1",
+        category="Assalto",
+        description="Assalto recente",
+        latitude=-5.0870,
+        longitude=-42.8080,
+        timestamp=datetime.now(timezone.utc)
+    )
+    review_recent.distance_from_route = 0.0
+    
+    _, score_recent = strategy.calculate([review_recent])
+    assert score_recent == 3
+
+    # 2. Registro com 30 dias de idade (Exata meia-vida da ocorrência)
+    # Peso efetivo cai pela metade: 3 * 0.5 = 1.5. Arredondado = 2
+    review_30_days = LocationReview(
+        id="2",
+        category="Assalto",
+        description="Assalto de 30 dias atrás",
+        latitude=-5.0870,
+        longitude=-42.8080,
+        timestamp=datetime.now(timezone.utc) - timedelta(days=30)
+    )
+    review_30_days.distance_from_route = 0.0
+    
+    _, score_30 = strategy.calculate([review_30_days])
+    assert score_30 == 2
+
+    # 3. Registro com 90 dias de idade (Três meias-vidas, atenuação severa)
+    # Peso efetivo = 3 * (0.5)^3 = 3 * 0.125 = 0.375. Arredondado = 0
+    review_90_days = LocationReview(
+        id="3",
+        category="Assalto",
+        description="Assalto antigo",
+        latitude=-5.0870,
+        longitude=-42.8080,
+        timestamp=datetime.now(timezone.utc) - timedelta(days=90)
+    )
+    review_90_days.distance_from_route = 0.0
+    
+    _, score_90 = strategy.calculate([review_90_days])
+    assert score_90 == 0

--- a/backend/tests/test_risk_decay.py
+++ b/backend/tests/test_risk_decay.py
@@ -7,6 +7,9 @@ def test_heuristic_strategy_spatial_decay():
     """Valida se ocorrências mais distantes têm seu risco atenuado corretamente"""
     strategy = HeuristicRiskStrategy()
     
+    # Adicionando um timedelta de +5 minutos no futuro para anular variação de microssegundos no teste
+    future_time = datetime.now(timezone.utc) + timedelta(minutes=5)
+    
     # 1. Distância = 0 metros (Sem atenuação)
     # Assalto tem peso base 3. Peso efetivo = 3 * 1.0 = 3
     review_on_route = LocationReview(
@@ -15,7 +18,7 @@ def test_heuristic_strategy_spatial_decay():
         description="Assalto na rota",
         latitude=-5.0870,
         longitude=-42.8080,
-        timestamp=datetime.now(timezone.utc)
+        timestamp=future_time
     )
     review_on_route.distance_from_route = 0.0
     
@@ -30,7 +33,7 @@ def test_heuristic_strategy_spatial_decay():
         description="Assalto a 50m",
         latitude=-5.0870,
         longitude=-42.8080,
-        timestamp=datetime.now(timezone.utc)
+        timestamp=future_time
     )
     review_mid_route.distance_from_route = 50.0
     
@@ -45,7 +48,7 @@ def test_heuristic_strategy_spatial_decay():
         description="Assalto a 90m",
         latitude=-5.0870,
         longitude=-42.8080,
-        timestamp=datetime.now(timezone.utc)
+        timestamp=future_time
     )
     review_far_route.distance_from_route = 90.0
     
@@ -58,14 +61,14 @@ def test_heuristic_strategy_temporal_decay():
     strategy = HeuristicRiskStrategy()
     
     # 1. Registro recente (0 dias) -> Sem atenuação temporal
-    # Assalto tem peso base 3. Peso efetivo = 3
+    # Definido no futuro para anular variação de microssegundos
     review_recent = LocationReview(
         id="1",
         category="Assalto",
         description="Assalto recente",
         latitude=-5.0870,
         longitude=-42.8080,
-        timestamp=datetime.now(timezone.utc)
+        timestamp=datetime.now(timezone.utc) + timedelta(minutes=5)
     )
     review_recent.distance_from_route = 0.0
     


### PR DESCRIPTION
## Descrição
Implementa regras de otimização e aprimoramento no cálculo de nível de risco de rotas no backend, tornando o serviço mais rápido, escalável e preciso. 
A partir de agora, o cálculo de risco do trajeto desconsidera ocorrências geograficamente distantes através de um filtro rápido de Bounding Box, e pondera o peso das ocorrências próximas com base na distância da ocorrência à rota (decaimento espacial) e na idade do registro (decaimento temporal).
## O que foi feito
- **Otimização de Performance:** Implementado o filtro rápido de Bounding Box no método `calculate_route_risk` do `risk_service.py`, reduzindo a complexidade de varredura e pulando cálculos trigonométricos para ocorrências fora da caixa geográfica da rota.
- **Decaimento Espacial:** Adicionado o cálculo de atenuação por distância em `risk_strategy.py`. Ocorrências mais distantes (dentro do raio de 100m) passam a influenciar menos a pontuação do que ocorrências mais próximas.
- **Decaimento Temporal:** Adicionada a atenuação exponencial com regra de meia-vida de 30 dias na estratégia `HeuristicRiskStrategy`. Ocorrências antigas têm seu peso atenuado progressivamente até serem zeradas.
- **Injeção Dinâmica:** Ajustado o `risk_service.py` para injetar a distância calculada no objeto de ocorrência de forma transparente para a estratégia de risco.
- **Testes Unitários:** Criada a suíte de testes unitários dedicada `test_risk_decay.py` para validar cenários de decaimento de risco por distância (0m, 50m, 90m) e por idade de registro (recente, 30 dias e 90 dias).
## Issue
Closes #89 