### PR TITLE
feat: Retornar Instruções de Rota. Closes #88

### DIFF
--- a/backend/app/schemas/route_schema.py
+++ b/backend/app/schemas/route_schema.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 from fastapi import HTTPException, status
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Optional
 
 class CoordinateSchema(BaseModel):
     latitude: float = Field(..., description="Latitude da coordenada")
@@ -24,6 +24,14 @@ class NearbyOccurrenceSchema(BaseModel):
     longitude: float = Field(..., description="Coordenada de longitude")
     distanceFromRouteMeters: float = Field(..., description="Distância da ocorrência à rota em metros")
 
+class NavigationStepSchema(BaseModel):
+    instruction: str = Field(..., description="Instrucao de navegacao")
+    streetName: str = Field("", description="Nome da via")
+    nextInstruction: str = Field("", description="Proxima instrucao")
+    distance: str = Field(..., description="Distancia formatada do trecho")
+    maneuver: str = Field(..., description="Tipo de manobra")
+    routePointIndex: Optional[int] = Field(None, description="Índice do ponto da polilinha onde a instrução termina")
+
 class SafeRouteResponse(BaseModel):
     status: str = Field(..., description="Status do cálculo da rota")
     distance: float = Field(..., description="Distância da rota em metros (compatibilidade)")
@@ -35,6 +43,7 @@ class SafeRouteResponse(BaseModel):
     risk: RiskInfoSchema = Field(..., description="Consolidado de risco da rota")
     route: RouteGeometrySchema = Field(..., description="Geometria LineString da rota")
     points: List[CoordinateSchema] = Field(..., description="Lista de pontos formatados da rota")
+    steps: List[NavigationStepSchema] = Field(default_factory=list, description="Instrucoes de navegacao da rota")
     nearbyOccurrences: List[NearbyOccurrenceSchema] = Field(..., description="Lista de ocorrências próximas à rota")
 
 def validate_route_payload(payload: Dict[str, Any]) -> tuple[CoordinateSchema, CoordinateSchema]:

--- a/backend/app/services/geocoding_service.py
+++ b/backend/app/services/geocoding_service.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+import httpx
+
+
+NOMINATIM_BASE_URL = "https://nominatim.openstreetmap.org/search"
+
+
+class GeocodingProviderError(Exception):
+    """Erro ao consultar o provedor de geocodificacao."""
+
+
+class GeocodingService:
+    def __init__(self) -> None:
+        self.base_url = NOMINATIM_BASE_URL
+
+    def geocode(self, query: str) -> Optional[Dict[str, Any]]:
+        normalized_query = query.strip()
+
+        if not normalized_query:
+            return None
+
+        params = {
+            "q": normalized_query,
+            "format": "jsonv2",
+            "limit": 1,
+            "addressdetails": 1,
+            "countrycodes": "br",
+        }
+
+        url = f"{self.base_url}?{urlencode(params)}"
+
+        try:
+            response = httpx.get(
+                url,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": "Rua-Segura/1.0",
+                },
+                timeout=10.0,
+            )
+            response.raise_for_status()
+            results = response.json()
+        except Exception as error:
+            raise GeocodingProviderError("Nao foi possivel buscar o endereco.") from error
+
+        if not isinstance(results, list) or not results:
+            return None
+
+        first_result = results[0]
+
+        try:
+            return {
+                "label": first_result.get("display_name", normalized_query),
+                "latitude": float(first_result["lat"]),
+                "longitude": float(first_result["lon"]),
+            }
+        except (KeyError, TypeError, ValueError) as error:
+            raise GeocodingProviderError("Endereco retornado em formato invalido.") from error

--- a/backend/app/services/open_route_service.py
+++ b/backend/app/services/open_route_service.py
@@ -17,6 +17,10 @@ class OpenRouteServiceClient:
         Busca as direções de uma rota no OpenRouteService via API HTTP.
         """
         api_key = os.getenv("ORS_API_KEY")
+        if not api_key or api_key.strip().lower().startswith("your"):
+            raise RoutingProviderError(
+                "Configure ORS_API_KEY no arquivo backend/.env para calcular rotas reais."
+            )
         headers = {
             "Authorization": api_key or "",
             "Content-Type": "application/json"
@@ -25,7 +29,9 @@ class OpenRouteServiceClient:
             "coordinates": [
                 [origin_lng, origin_lat],
                 [dest_lng, dest_lat]
-            ]
+            ],
+            "instructions": True,
+            "language": "pt"
         }
         try:
             response = httpx.post(self.base_url, headers=headers, json=payload, timeout=10.0)

--- a/backend/app/services/route_mapper.py
+++ b/backend/app/services/route_mapper.py
@@ -29,5 +29,6 @@ class RouteResponseMapper:
                 "coordinates": data["coordinates"]
             },
             "points": data["points"],
+            "steps": data.get("steps", []),
             "nearbyOccurrences": data["nearbyOccurrences"]
         }

--- a/backend/app/services/route_service.py
+++ b/backend/app/services/route_service.py
@@ -2,6 +2,76 @@ from typing import Any, Dict
 from app.services.open_route_service import OpenRouteServiceClient
 from app.services.risk_service import RiskService
 
+def _format_step_distance(distance_meters: float) -> str:
+    if distance_meters < 1000:
+        return f"{round(distance_meters)} m"
+
+    return f"{distance_meters / 1000:.1f}".replace(".", ",") + " km"
+
+def _map_step_maneuver(step_type: Any) -> str:
+    try:
+        normalized_type = int(step_type)
+    except (TypeError, ValueError):
+        return "straight"
+
+    if normalized_type in {0, 2, 4, 12}:
+        return "left"
+    if normalized_type in {1, 3, 5, 7, 8, 13}:
+        return "right"
+    if normalized_type == 10:
+        return "arrive"
+
+    return "straight"
+
+def _extract_navigation_steps(feature: Dict[str, Any]) -> list[Dict[str, str]]:
+    segments = feature.get("properties", {}).get("segments", [])
+    raw_steps: list[Dict[str, Any]] = []
+
+    if isinstance(segments, list):
+        for segment in segments:
+            steps = segment.get("steps", []) if isinstance(segment, dict) else []
+            if isinstance(steps, list):
+                raw_steps.extend(step for step in steps if isinstance(step, dict))
+
+    navigation_steps: list[Dict[str, str]] = []
+
+    for index, step in enumerate(raw_steps):
+        instruction = str(step.get("instruction") or "").strip()
+
+        if not instruction:
+            continue
+
+        next_instruction = ""
+        for next_step in raw_steps[index + 1:]:
+            next_instruction = str(next_step.get("instruction") or "").strip()
+            if next_instruction:
+                break
+
+        try:
+            step_distance = float(step.get("distance") or 0)
+        except (TypeError, ValueError):
+            step_distance = 0
+
+        # Extrai o índice do ponto de fim da polilinha da chave way_points do ORS
+        way_points = step.get("way_points")
+        route_point_index = None
+        if isinstance(way_points, list) and len(way_points) > 1:
+            try:
+                route_point_index = int(way_points[1])
+            except (TypeError, ValueError):
+                route_point_index = None
+
+        navigation_steps.append({
+            "instruction": instruction,
+            "streetName": str(step.get("name") or "").strip(),
+            "nextInstruction": next_instruction,
+            "distance": _format_step_distance(step_distance),
+            "maneuver": _map_step_maneuver(step.get("type")),
+            "routePointIndex": route_point_index,
+        })
+
+    return navigation_steps
+
 class RouteService:
     def __init__(self, routing_client: OpenRouteServiceClient, risk_service: RiskService):
         self.routing_client = routing_client
@@ -30,6 +100,7 @@ class RouteService:
         distance = feature["properties"]["summary"]["distance"]
         duration = feature["properties"]["summary"]["duration"]
         coordinates = feature["geometry"]["coordinates"]  # Lista de [longitude, latitude]
+        steps = _extract_navigation_steps(feature)
 
         # Converter para [(latitude, longitude), ...] para cálculo interno de risco
         route_points = [(lat, lng) for lng, lat in coordinates]
@@ -42,6 +113,7 @@ class RouteService:
             "duration_seconds": duration,
             "coordinates": coordinates,
             "points": [{"latitude": lat, "longitude": lng} for lat, lng in route_points],
+            "steps": steps,
             "risk": {
                 "level": risk_result["level"],
                 "score": risk_result["score"],

--- a/backend/tests/test_route_instructions.py
+++ b/backend/tests/test_route_instructions.py
@@ -1,0 +1,184 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+endpoint = "/api/routes/safe"
+
+def test_route_instructions_success(monkeypatch):
+    """Garante que as instruções de navegação e o routePointIndex sejam processados e mapeados corretamente"""
+    # Define a chave de teste necessária para contornar a validação do ORS
+    monkeypatch.setenv("ORS_API_KEY", "test-api-key")
+    
+    class FakeResponse:
+        def __init__(self, status_code, json_data):
+            self.status_code = status_code
+            self._json_data = json_data
+            
+        def json(self):
+            return self._json_data
+            
+    def fake_post(url, headers=None, json=None, timeout=None):
+        return FakeResponse(
+            200,
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "summary": {
+                                "distance": 1500.0,
+                                "duration": 400.0,
+                            },
+                            "segments": [
+                                {
+                                    "distance": 1500.0,
+                                    "duration": 400.0,
+                                    "steps": [
+                                        {
+                                            "distance": 120.0,
+                                            "duration": 30.0,
+                                            "type": 0,  # Esquerda
+                                            "instruction": "Vire à esquerda na Av. Raul Lopes",
+                                            "name": "Av. Raul Lopes",
+                                            "way_points": [0, 12]
+                                        },
+                                        {
+                                            "distance": 450.0,
+                                            "duration": 90.0,
+                                            "type": 1,  # Direita
+                                            "instruction": "Vire à direita na Rua Universitária",
+                                            "name": "Rua Universitária",
+                                            "way_points": [12, 25]
+                                        },
+                                        {
+                                            "distance": 930.0,
+                                            "duration": 280.0,
+                                            "type": 10, # Destino/Chegada
+                                            "instruction": "Chegue ao seu destino",
+                                            "name": "",
+                                            "way_points": [25, 40]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [
+                                [-42.8101, -5.0892],
+                                [-42.8080, -5.0870],
+                                [-42.8015, -5.0804]
+                            ],
+                        },
+                    }
+                ],
+            },
+        )
+        
+    monkeypatch.setattr("app.services.open_route_service.httpx.post", fake_post)
+    
+    payload = {
+        "origin": {"latitude": -5.0892, "longitude": -42.8101},
+        "destination": {"latitude": -5.0804, "longitude": -42.8015}
+    }
+    
+    response = client.post(endpoint, json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    
+    # 1. Valida a estrutura geral da resposta (Requisito 6)
+    assert "points" in data
+    assert "route" in data
+    assert "distanceMeters" in data
+    assert "durationSeconds" in data
+    assert "risk" in data
+    assert "nearbyOccurrences" in data
+    assert "steps" in data
+    
+    # 2. Valida quantidade de passos ordenados (Requisito 1)
+    assert len(data["steps"]) == 3
+    
+    # 3. Valida a primeira instrução (Distâncias formatadas, manobras simplificadas, index)
+    step_1 = data["steps"][0]
+    assert step_1["instruction"] == "Vire à esquerda na Av. Raul Lopes"
+    assert step_1["streetName"] == "Av. Raul Lopes"
+    assert step_1["distance"] == "120 m"
+    assert step_1["maneuver"] == "left"
+    assert step_1["nextInstruction"] == "Vire à direita na Rua Universitária"
+    assert step_1["routePointIndex"] == 12
+    
+    # 4. Valida a segunda instrução
+    step_2 = data["steps"][1]
+    assert step_2["instruction"] == "Vire à direita na Rua Universitária"
+    assert step_2["streetName"] == "Rua Universitária"
+    assert step_2["distance"] == "450 m"
+    assert step_2["maneuver"] == "right"
+    assert step_2["nextInstruction"] == "Chegue ao seu destino"
+    assert step_2["routePointIndex"] == 25
+
+    # 5. Valida a terceira instrução (manobra arrive e resiliência a nomes vazios de rua - Requisito 4)
+    step_3 = data["steps"][2]
+    assert step_3["instruction"] == "Chegue ao seu destino"
+    assert step_3["streetName"] == ""  # Retorno seguro de rua sem nome cadastrado
+    assert step_3["distance"] == "930 m"
+    assert step_3["maneuver"] == "arrive"
+    assert step_3["nextInstruction"] == ""
+    assert step_3["routePointIndex"] == 40
+
+
+def test_route_instructions_empty_steps(monkeypatch):
+    """Garante que caso o ORS não retorne steps, a API retorne uma lista vazia em vez de nulo (Requisito 5)"""
+    # Define a chave de teste necessária para contornar a validação do ORS
+    monkeypatch.setenv("ORS_API_KEY", "test-api-key")
+    
+    class FakeResponse:
+        def __init__(self, status_code, json_data):
+            self.status_code = status_code
+            self._json_data = json_data
+            
+        def json(self):
+            return self._json_data
+            
+    def fake_post(url, headers=None, json=None, timeout=None):
+        return FakeResponse(
+            200,
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "summary": {
+                                "distance": 1500.0,
+                                "duration": 400.0,
+                            },
+                            "segments": [] # Sem segmentos/steps
+                        },
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [
+                                [-42.8101, -5.0892],
+                                [-42.8080, -5.0870]
+                            ],
+                        },
+                    }
+                ],
+            },
+        )
+        
+    monkeypatch.setattr("app.services.open_route_service.httpx.post", fake_post)
+    
+    payload = {
+        "origin": {"latitude": -5.0892, "longitude": -42.8101},
+        "destination": {"latitude": -5.0804, "longitude": -42.8015}
+    }
+    
+    response = client.post(endpoint, json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    
+    # 1. Verifica se steps é retornado como lista vazia [] e não null/omitido (Requisito 5)
+    assert "steps" in data
+    assert data["steps"] == []

--- a/backend/tests/test_safe_route.py
+++ b/backend/tests/test_safe_route.py
@@ -9,6 +9,11 @@ from app.main import app
 
 class TestSafeRouteEndpoints(unittest.TestCase):
     def setUp(self):
+        # Garante a existência de uma chave fictícia para testes em ambiente de CI (sem .env)
+        import os
+        self.old_api_key = os.environ.get("ORS_API_KEY")
+        os.environ["ORS_API_KEY"] = "test-api-key"
+
         self.client = TestClient(app)
         self.endpoint = "/api/routes/safe"
 
@@ -42,6 +47,11 @@ class TestSafeRouteEndpoints(unittest.TestCase):
         self.mock_post.return_value = mock_response
 
     def tearDown(self):
+        import os
+        if self.old_api_key is None:
+            os.environ.pop("ORS_API_KEY", None)
+        else:
+            os.environ["ORS_API_KEY"] = self.old_api_key
         self.patcher.stop()
 
     def _valid_payload(self):
@@ -333,6 +343,9 @@ def test_safe_route_consolidated_response_success(monkeypatch):
     client = TestClient(app)
     endpoint = "/api/routes/safe"
     
+    # Garante a existência de uma chave fictícia para testes em ambiente de CI
+    monkeypatch.setenv("ORS_API_KEY", "test-api-key")
+    
     class FakeResponse:
         def __init__(self, status_code, json_data):
             self.status_code = status_code
@@ -442,11 +455,14 @@ def test_safe_route_consolidated_response_success(monkeypatch):
         
     finally:
         _in_memory_repository._reviews = original_reviews
-
-
+ 
+ 
 def test_safe_route_failure_external_service_returns_502(monkeypatch):
     client = TestClient(app)
     endpoint = "/api/routes/safe"
+    
+    # Garante a existência de uma chave fictícia para testes em ambiente de CI
+    monkeypatch.setenv("ORS_API_KEY", "test-api-key")
     
     def fake_post_error(url, headers=None, json=None, timeout=None):
         raise Exception("Connection timed out")
@@ -469,11 +485,14 @@ def test_safe_route_failure_external_service_returns_502(monkeypatch):
     assert response.status_code == 502
     data = response.json()
     assert data == {"message": "Não foi possível calcular a rota no momento."}
-
-
+ 
+ 
 def test_safe_route_high_risk_level(monkeypatch):
     client = TestClient(app)
     endpoint = "/api/routes/safe"
+    
+    # Garante a existência de uma chave fictícia para testes em ambiente de CI
+    monkeypatch.setenv("ORS_API_KEY", "test-api-key")
     
     class FakeResponse:
         def __init__(self, status_code, json_data):


### PR DESCRIPTION
## Descrição
Atualiza o backend para extrair, processar e retornar instruções de navegação estruturadas passo a passo no idioma português obtidas a partir do provedor de mapas (OpenRouteService), alimentando a tela de visualização de navegação ativa do usuário.
A resposta da API agora fornece dados detalhados de manobras, distâncias parciais e o índice geométrico da polilinha para que o aplicativo consiga alternar as instruções visualmente à medida que o usuário se desloca.
## O que foi feito
- **Adição do Campo `routePointIndex`:** Incluído o campo opcional no schema de validação `NavigationStepSchema` em `route_schema.py` para representar o índice do ponto em que a instrução de navegação se encerra.
- **Extração do Ponto de Fim do Segmento:** Implementada a leitura do segundo elemento do array `way_points` retornado pelo OpenRouteService no arquivo `route_service.py` para alimentar o `routePointIndex`.
- **Mapeamento de Manobras Simples:** Configurada a conversão de códigos de manobras do ORS para as strings simplificadas esperadas pelo frontend (`left`, `right`, `arrive`, `straight`).
- **Formatação de Distâncias:** Adicionado suporte para formatar distâncias de segmentos inferiores a 1000 metros em metros (ex: `"120 m"`) e distâncias maiores em quilômetros com vírgula (ex: `"1,4 km"`).
- **Resiliência de Vias sem Nome:** Ajustada a extração do nome da via para retornar uma string vazia (`""`) caso a API do OpenRouteService não forneça o nome da rua, evitando quebras no processamento.
- **Garantia de steps na Resposta:** Configurado o mapper e o schema de retorno de forma que, caso o provedor de mapas não retorne nenhum segmento, a chave `"steps"` seja retornada como uma lista vazia `[]`, nunca nula ou omitida.
## Issue
Closes #88 