### PR TITLE
feat: Integrar frontend com backend no fluxo de rotas. Closes #91

### DIFF
--- a/backend/app/controllers/route_controller.py
+++ b/backend/app/controllers/route_controller.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, status, HTTPException
+from fastapi import APIRouter, Query, status, HTTPException
 from fastapi.responses import JSONResponse
 from typing import Any, Dict
 from app.schemas.route_schema import validate_route_payload, SafeRouteResponse
+from app.services.geocoding_service import GeocodingProviderError, GeocodingService
 from app.services.open_route_service import OpenRouteServiceClient, RoutingProviderError
 from app.services.route_service import RouteService
 from app.services.route_mapper import RouteResponseMapper
@@ -12,6 +13,29 @@ router = APIRouter(prefix="/api/routes", tags=["Rotas Seguras"])
 # Instanciamos o client e o RouteService reutilizando o RiskService existente
 _routing_client = OpenRouteServiceClient()
 _route_service = RouteService(_routing_client, _risk_service)
+_geocoding_service = GeocodingService()
+
+
+@router.get("/geocode")
+def geocode_route_location(query: str = Query(..., min_length=3)):
+    """
+    Resolve um texto de endereco em coordenadas reais para calculo de rota.
+    """
+    try:
+        result = _geocoding_service.geocode(query)
+    except GeocodingProviderError:
+        return JSONResponse(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            content={"message": "Nao foi possivel buscar esse endereco no momento."}
+        )
+
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Endereco nao encontrado"
+        )
+
+    return result
 
 @router.post("/safe", response_model=SafeRouteResponse, status_code=status.HTTP_200_OK)
 def calculate_safe_route(payload: Dict[str, Any]):

--- a/frontend/components/ActiveRouteScreen.tsx
+++ b/frontend/components/ActiveRouteScreen.tsx
@@ -1090,7 +1090,7 @@ export default function ActiveRouteScreen() {
             isCopying={isCopying}
             errorMessage={errorMessage}
             successMessage={successMessage}
-            onStartSharing={() => startSharing(currentLocation, destination, routeCoordinates)}
+            onStartSharing={() => startSharing(currentLocation, destination)}
             onStopSharing={stopSharing}
             onCopyLink={copyShareLink}
             onClose={() => setIsSecurityOpen(false)}

--- a/frontend/components/ActiveRouteScreen.tsx
+++ b/frontend/components/ActiveRouteScreen.tsx
@@ -29,6 +29,7 @@ type NavigationStep = {
   nextInstruction: string;
   distance: string;
   maneuver: NavigationManeuver;
+  routePointIndex?: number | null;
 };
 
 type ActiveRouteParams = {
@@ -64,6 +65,13 @@ const FALLBACK_DISTANCE = '2,4 km';
 const FALLBACK_RISK = 'Baixo';
 const ANDROID_NAV_FALLBACK_BOTTOM = 42;
 
+const STATIC_ROUTE_SUMMARY = {
+  estimatedTime: '8 min',
+  totalDistance: '2,4 km',
+  riskLevel: 'Baixo risco',
+  routeMessage: 'Rota segura no momento. Os dados deste card estão estáticos por enquanto.',
+};
+
 const MARKER_DOT_GREEN = require('../assets/images/marker-dot-green.png');
 const USER_LOCATION_MARKER = require('../assets/images/user-location.png');
 
@@ -98,7 +106,7 @@ const MOCK_ACTIVE_ROUTE = {
       distance: '120 m',
       maneuver: 'right' as NavigationManeuver,
     },
-  ],
+  ] as NavigationStep[],
 };
 
 let MapView: any = null;
@@ -128,22 +136,7 @@ function createMockRouteLine(
   origin: RouteCoordinates,
   destination: RouteCoordinates,
 ): RouteCoordinates[] {
-  return [
-    origin,
-    {
-      latitude: origin.latitude + 0.0012,
-      longitude: origin.longitude + 0.001,
-    },
-    {
-      latitude: origin.latitude + 0.002,
-      longitude: origin.longitude + 0.0024,
-    },
-    {
-      latitude: destination.latitude - 0.0008,
-      longitude: destination.longitude - 0.0006,
-    },
-    destination,
-  ];
+  return [origin, destination];
 }
 
 function isValidCoordinate(coord: RouteCoordinates) {
@@ -222,6 +215,7 @@ function parseStepsFromJson(value?: string): NavigationStep[] | null {
         const nextInstruction = String(item.nextInstruction ?? '').trim();
         const distance = String(item.distance ?? '').trim();
         const maneuver = String(item.maneuver ?? 'straight') as NavigationManeuver;
+        const routePointIndex = Number(item.routePointIndex);
 
         if (!instruction) return null;
 
@@ -233,6 +227,7 @@ function parseStepsFromJson(value?: string): NavigationStep[] | null {
           maneuver: ['straight', 'left', 'right', 'arrive'].includes(maneuver)
             ? maneuver
             : 'straight',
+          routePointIndex: Number.isFinite(routePointIndex) ? routePointIndex : null,
         };
       })
       .filter(Boolean) as NavigationStep[];
@@ -317,6 +312,7 @@ function EmptyNavigationState({ onBack }: { onBack: () => void }) {
 type ActiveRouteMapProps = {
   origin: RouteCoordinates;
   destination: RouteCoordinates;
+  currentLocation: RouteCoordinates;
   originName: string;
   destinationName: string;
   routeCoordinates: RouteCoordinates[];
@@ -326,6 +322,7 @@ type ActiveRouteMapProps = {
 function ActiveRouteMap({
   origin,
   destination,
+  currentLocation,
   originName,
   destinationName,
   routeCoordinates,
@@ -336,6 +333,7 @@ function ActiveRouteMap({
 
   const webMapRef = useRef<any>(null);
   const webMarkersRef = useRef<any[]>([]);
+  const webUserMarkerRef = useRef<any>(null);
   const webPolylineRef = useRef<any>(null);
   const nativeMapRef = useRef<any>(null);
 
@@ -456,33 +454,33 @@ function ActiveRouteMap({
         className: 'user-current-icon',
         html: `
           <div style="
-            width:52px;
-            height:52px;
-            border-radius:26px;
-            background:rgba(20,115,230,0.14);
+            width:48px;
+            height:48px;
+            border-radius:24px;
+            background:rgba(20,115,230,0.16);
             display:flex;
             align-items:center;
             justify-content:center;
           ">
             <div style="
-              width:42px;
-              height:42px;
-              border-radius:21px;
+              width:38px;
+              height:38px;
+              border-radius:19px;
               background:white;
               display:flex;
               align-items:center;
               justify-content:center;
               box-shadow:0 5px 12px rgba(0,0,0,0.25);
               color:#1473E6;
-              font-size:23px;
+              font-size:21px;
               font-weight:900;
             ">
               ➤
             </div>
           </div>
         `,
-        iconSize: [52, 52],
-        iconAnchor: [26, 26],
+        iconSize: [48, 48],
+        iconAnchor: [24, 24],
       });
 
       const originMarker = L.marker([origin.latitude, origin.longitude], {
@@ -501,11 +499,12 @@ function ActiveRouteMap({
         .bindPopup(`<b>Destino</b><br/>${destinationName}`);
 
       const userMarker = L.marker(
-        [MOCK_USER_POSITION.latitude, MOCK_USER_POSITION.longitude],
+        [currentLocation.latitude, currentLocation.longitude],
         {
           icon: userIcon,
         },
       ).addTo(map);
+      webUserMarkerRef.current = userMarker;
 
       webMarkersRef.current.push(originMarker, destinationMarker, userMarker);
 
@@ -549,6 +548,7 @@ function ActiveRouteMap({
     return () => {
       webMarkersRef.current.forEach((marker) => marker.remove());
       webMarkersRef.current = [];
+      webUserMarkerRef.current = null;
 
       if (webPolylineRef.current) {
         webPolylineRef.current.remove();
@@ -576,6 +576,15 @@ function ActiveRouteMap({
     mapInitialRegion.latitude,
     mapInitialRegion.longitude,
   ]);
+
+  useEffect(() => {
+    if (!isWeb || !webUserMarkerRef.current) return;
+
+    webUserMarkerRef.current.setLatLng([
+      currentLocation.latitude,
+      currentLocation.longitude,
+    ]);
+  }, [currentLocation.latitude, currentLocation.longitude, isWeb]);
 
   if (isWeb) {
     return (
@@ -639,8 +648,8 @@ function ActiveRouteMap({
       />
 
       <Marker
-        coordinate={MOCK_USER_POSITION}
-        title="Você está aqui"
+        coordinate={currentLocation}
+        title="Posicao simulada"
         image={USER_LOCATION_MARKER}
         anchor={{ x: 0.5, y: 0.5 }}
         centerOffset={{ x: 0, y: 0 }}
@@ -783,6 +792,7 @@ function BottomNavigationCard({
   estimatedTime,
   totalDistance,
   riskLevel,
+  routeMessage,
   bottomOffset,
   onExit,
   onRecenter,
@@ -791,6 +801,7 @@ function BottomNavigationCard({
   estimatedTime: string;
   totalDistance: string;
   riskLevel: string;
+  routeMessage: string;
   bottomOffset: number;
   onExit: () => void;
   onRecenter: () => void;
@@ -825,6 +836,10 @@ function BottomNavigationCard({
             </Text>
           </View>
         </View>
+
+        <Text style={styles.bottomRiskMessage} numberOfLines={2}>
+          {routeMessage}
+        </Text>
       </View>
 
       <View style={styles.bottomActionsRow}>
@@ -862,6 +877,7 @@ export default function ActiveRouteScreen() {
 
   const [recenterSignal, setRecenterSignal] = useState(0);
   const [isSecurityOpen, setIsSecurityOpen] = useState(false);
+  const [simulatedPointIndex, setSimulatedPointIndex] = useState(0);
 
   const {
     activeSession,
@@ -873,22 +889,19 @@ export default function ActiveRouteScreen() {
     startSharing,
     stopSharing,
     copyShareLink,
+    updateSharingLocation,
   } = useShareTrip();
 
   const originName = String(params.originName ?? '').trim();
   const destinationName = String(params.destinationName ?? '').trim();
 
-  const estimatedTime = String(
-    params.estimatedTime ?? MOCK_ACTIVE_ROUTE.estimatedTime,
-  ).trim();
+  const estimatedTime = STATIC_ROUTE_SUMMARY.estimatedTime;
 
-  const totalDistance = String(
-    params.totalDistance ?? MOCK_ACTIVE_ROUTE.totalDistance,
-  ).trim();
+  const totalDistance = STATIC_ROUTE_SUMMARY.totalDistance;
 
-  const riskLevel = String(
-    params.riskLevel ?? MOCK_ACTIVE_ROUTE.currentRisk,
-  ).trim();
+  const riskLevel = STATIC_ROUTE_SUMMARY.riskLevel;
+
+  const routeMessage = STATIC_ROUTE_SUMMARY.routeMessage;
 
   const origin: RouteCoordinates = {
     latitude: parseCoord(params.originLatitude, MOCK_USER_POSITION.latitude),
@@ -922,7 +935,51 @@ export default function ActiveRouteScreen() {
   }, [origin, destination, parsedRouteCoordinates]);
 
   const steps = parsedSteps ?? MOCK_ACTIVE_ROUTE.steps;
-  const currentStep = steps[MOCK_ACTIVE_ROUTE.currentStepIndex] ?? steps[0];
+  const currentLocation = routeCoordinates[
+    Math.min(simulatedPointIndex, routeCoordinates.length - 1)
+  ] ?? origin;
+  const hasArrived =
+    routeCoordinates.length > 1 && simulatedPointIndex >= routeCoordinates.length - 1;
+  const currentStepIndex = useMemo(() => {
+    if (!steps.length || routeCoordinates.length < 2) return 0;
+
+    const stepWithRoutePoint = steps
+      .map((step, index) => ({
+        index,
+        routePointIndex: Number(step.routePointIndex),
+      }))
+      .filter(({ routePointIndex }) => Number.isFinite(routePointIndex))
+      .sort((a, b) => a.routePointIndex - b.routePointIndex);
+
+    if (!stepWithRoutePoint.length) {
+      const estimatedIndex = Math.floor(
+        (simulatedPointIndex / Math.max(routeCoordinates.length - 1, 1)) * steps.length,
+      );
+
+      return Math.min(estimatedIndex, steps.length - 1);
+    }
+
+    let activeIndex = stepWithRoutePoint[0].index;
+
+    for (const step of stepWithRoutePoint) {
+      if (simulatedPointIndex <= step.routePointIndex) {
+        return step.index;
+      }
+
+      activeIndex = step.index;
+    }
+
+    return activeIndex;
+  }, [routeCoordinates.length, simulatedPointIndex, steps]);
+  const arrivalStep: NavigationStep = useMemo(() => ({
+    instruction: 'Você chegou ao seu destino',
+    streetName: destinationName,
+    nextInstruction: '',
+    distance: '0 m',
+    maneuver: 'arrive',
+    routePointIndex: routeCoordinates.length - 1,
+  }), [destinationName, routeCoordinates.length]);
+  const currentStep = hasArrived ? arrivalStep : steps[currentStepIndex] ?? steps[0];
 
   const hasRouteData = originName.length > 0 && destinationName.length > 0;
   const isCompactScreen = width < 370 || height < 700;
@@ -953,6 +1010,32 @@ export default function ActiveRouteScreen() {
     setRecenterSignal((current) => current + 1);
   }, []);
 
+  useEffect(() => {
+    setSimulatedPointIndex(0);
+  }, [params.routeCoordinatesJson]);
+
+  useEffect(() => {
+    if (routeCoordinates.length < 2) return undefined;
+
+    const interval = setInterval(() => {
+      setSimulatedPointIndex((current) => {
+        if (current >= routeCoordinates.length - 1) {
+          return current;
+        }
+
+        return current + 1;
+      });
+    }, 2200);
+
+    return () => clearInterval(interval);
+  }, [routeCoordinates.length]);
+
+  useEffect(() => {
+    if (!activeSession) return;
+
+    void updateSharingLocation(currentLocation);
+  }, [activeSession, currentLocation, updateSharingLocation]);
+
   if (!hasRouteData) {
     return <EmptyNavigationState onBack={() => router.back()} />;
   }
@@ -969,6 +1052,7 @@ export default function ActiveRouteScreen() {
         <ActiveRouteMap
           origin={origin}
           destination={destination}
+          currentLocation={currentLocation}
           originName={originName}
           destinationName={destinationName}
           routeCoordinates={routeCoordinates}
@@ -992,6 +1076,7 @@ export default function ActiveRouteScreen() {
           estimatedTime={estimatedTime}
           totalDistance={totalDistance}
           riskLevel={riskLevel}
+          routeMessage={routeMessage}
           bottomOffset={bottomCardOffset}
           onExit={() => router.back()}
           onRecenter={handleRecenter}
@@ -1005,7 +1090,7 @@ export default function ActiveRouteScreen() {
             isCopying={isCopying}
             errorMessage={errorMessage}
             successMessage={successMessage}
-            onStartSharing={() => startSharing(origin, destination)}
+            onStartSharing={() => startSharing(currentLocation, destination, routeCoordinates)}
             onStopSharing={stopSharing}
             onCopyLink={copyShareLink}
             onClose={() => setIsSecurityOpen(false)}
@@ -1290,6 +1375,14 @@ const styles = StyleSheet.create({
     color: COLORS.warning,
     fontSize: 15,
     fontWeight: '900',
+  },
+
+  bottomRiskMessage: {
+    marginTop: 6,
+    color: COLORS.textMuted,
+    fontSize: 13,
+    fontWeight: '600',
+    lineHeight: 18,
   },
 
   riskBadge: {

--- a/frontend/components/RouteMapScreen.tsx
+++ b/frontend/components/RouteMapScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   StyleSheet,
   View,
@@ -6,10 +6,18 @@ import {
   TouchableOpacity,
   Platform,
   StatusBar,
+  ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter, useLocalSearchParams} from 'expo-router';
+import {
+  calculateSafeRoute,
+  formatRiskLevel,
+  formatRouteDistance,
+  formatRouteDuration,
+  SafeRouteSearchResult,
+} from '../services/routeService';
 
 type RouteCoordinates = {
   latitude: number;
@@ -23,6 +31,7 @@ type RouteMapParams = {
   originLongitude?: string;
   destinationLatitude?: string;
   destinationLongitude?: string;
+  routeData?: string;
 };
 
 const FALLBACK_ORIGIN: RouteCoordinates = {
@@ -58,39 +67,41 @@ function parseCoord(value: string | undefined, fallback: number): number {
   return Number.isNaN(parsed) ? fallback : parsed;
 }
 
-function createMockRouteLine(
-  origin: RouteCoordinates,
-  destination: RouteCoordinates,
-): RouteCoordinates[] {
-  // Rota mockada apenas para preparar a tela.
-  // A linha real será substituída futuramente pela rota calculada pela API.
-  return [
-    origin,
-    {
-      latitude: origin.latitude + 0.0012,
-      longitude: origin.longitude + 0.001,
-    },
-    {
-      latitude: origin.latitude + 0.002,
-      longitude: origin.longitude + 0.0024,
-    },
-    {
-      latitude: destination.latitude - 0.0008,
-      longitude: destination.longitude - 0.0006,
-    },
-    destination,
-  ];
+
+function parseRouteData(value: string | undefined): SafeRouteSearchResult | null {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value) as SafeRouteSearchResult;
+    return Array.isArray(parsed.points) && parsed.points.length > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 type RouteSummaryCardProps = {
   originName: string;
   destinationName: string;
+  distanceLabel: string;
+  durationLabel: string;
+  riskLabel: string;
+  riskDescription: string;
+  errorMessage: string | null;
+  isLoading: boolean;
+  onRetry: () => void;
   onStartRoute: () => void;
 };
 
 function RouteSummaryCard({
   originName,
   destinationName,
+  distanceLabel,
+  durationLabel,
+  riskLabel,
+  riskDescription,
+  errorMessage,
+  isLoading,
+  onRetry,
   onStartRoute,
 }: RouteSummaryCardProps) {
   return (
@@ -98,13 +109,38 @@ function RouteSummaryCard({
       <View style={styles.summaryTopRow}>
         <View>
           <Text style={styles.summaryTitle}>Rota recomendada</Text>
-          <Text style={styles.summaryDistance}>2,4 km • 8 min</Text>
+          <Text style={styles.summaryDistance}>{distanceLabel} - {durationLabel}</Text>
         </View>
 
         <View style={styles.riskBadge}>
-          <Text style={styles.riskBadgeText}>Baixo risco</Text>
+          <Text style={styles.riskBadgeText}>{riskLabel}</Text>
         </View>
       </View>
+
+      <View style={styles.routeMetricsRow}>
+        <Text style={styles.routeMetricText}>{distanceLabel}</Text>
+        <Text style={styles.routeMetricSeparator}>|</Text>
+        <Text style={styles.routeMetricText}>{durationLabel}</Text>
+        <Text style={styles.routeMetricSeparator}>|</Text>
+        <Text style={styles.routeMetricText}>{riskLabel}</Text>
+      </View>
+
+      {isLoading && (
+        <View style={styles.routeFeedbackBox}>
+          <ActivityIndicator size="small" color="#16A34A" />
+          <Text style={styles.routeFeedbackText}>Calculando rota segura...</Text>
+        </View>
+      )}
+
+      {errorMessage && (
+        <View style={styles.routeErrorBox}>
+          <Ionicons name="alert-circle-outline" size={18} color="#DC2626" />
+          <Text style={styles.routeErrorText}>{errorMessage}</Text>
+          <TouchableOpacity onPress={onRetry} style={styles.retryButton}>
+            <Text style={styles.retryButtonText}>Tentar</Text>
+          </TouchableOpacity>
+        </View>
+      )}
 
       <View style={styles.routePointsBox}>
         <View style={styles.routeDotsColumn}>
@@ -125,6 +161,7 @@ function RouteSummaryCard({
 
       <View style={styles.reasonBox}>
         <Text style={styles.reasonTitle}>Por que essa rota?</Text>
+        <Text style={styles.reasonText}>{riskDescription}</Text>
 
         <Text style={styles.reasonText}>
           Esta rota evita áreas com maior concentração de ocorrências e prioriza
@@ -136,6 +173,7 @@ function RouteSummaryCard({
         style={styles.startRouteButton}
         activeOpacity={0.85}
         onPress={onStartRoute}
+        disabled={isLoading || !!errorMessage}
       >
         <Text style={styles.startRouteButtonText}>Iniciar rota</Text>
       </TouchableOpacity>
@@ -166,6 +204,10 @@ export default function RouteMapScreen() {
 
   const originName = params.originName ?? '';
   const destinationName = params.destinationName ?? '';
+  const initialRouteData = parseRouteData(params.routeData);
+  const [safeRoute, setSafeRoute] = useState<SafeRouteSearchResult | null>(initialRouteData);
+  const [isRouteLoading, setIsRouteLoading] = useState(false);
+  const [routeErrorMessage, setRouteErrorMessage] = useState<string | null>(null);
 
   const hasOriginCoords =
     params.originLatitude != null && params.originLongitude != null;
@@ -202,7 +244,53 @@ export default function RouteMapScreen() {
   const initialOrigin = originCoords ?? FALLBACK_ORIGIN;
   const initialDestination = destinationCoords ?? FALLBACK_DESTINATION;
 
-  const routeLineCoords = createMockRouteLine(initialOrigin, initialDestination);
+  const routeLineCoords = useMemo(
+    () => (safeRoute?.points && safeRoute.points.length > 0 ? safeRoute.points : []),
+    [safeRoute],
+  );
+
+  const distanceLabel = safeRoute ? formatRouteDistance(safeRoute.distanceMeters) : '-- km';
+  const durationLabel = safeRoute ? formatRouteDuration(safeRoute.durationSeconds) : '-- min';
+  const riskLabel = safeRoute ? formatRiskLevel(safeRoute.risk.level) : 'Calculando';
+  const riskDescription = safeRoute?.risk.description || 'A rota segura sera exibida assim que o calculo terminar.';
+
+  const loadSafeRoute = useCallback(async () => {
+    if (!hasOriginCoords || !hasDestinationCoords) return;
+
+    setIsRouteLoading(true);
+    setRouteErrorMessage(null);
+
+    try {
+      const route = await calculateSafeRoute({
+        origin: {
+          latitude: initialOrigin.latitude,
+          longitude: initialOrigin.longitude,
+        },
+        destination: {
+          latitude: initialDestination.latitude,
+          longitude: initialDestination.longitude,
+        },
+      });
+      setSafeRoute(route);
+    } catch (error: any) {
+      setRouteErrorMessage(error?.message || 'Nao foi possivel calcular a rota segura.');
+    } finally {
+      setIsRouteLoading(false);
+    }
+  }, [
+    hasOriginCoords,
+    hasDestinationCoords,
+    initialOrigin.latitude,
+    initialOrigin.longitude,
+    initialDestination.latitude,
+    initialDestination.longitude,
+  ]);
+
+  useEffect(() => {
+    if (!safeRoute && hasOriginCoords && hasDestinationCoords) {
+      loadSafeRoute();
+    }
+  }, [hasDestinationCoords, hasOriginCoords, loadSafeRoute, safeRoute]);
 
   const handleStartRoute = () => {
     router.push({
@@ -214,9 +302,11 @@ export default function RouteMapScreen() {
         originLongitude: String(initialOrigin.longitude),
         destinationLatitude: String(initialDestination.latitude),
         destinationLongitude: String(initialDestination.longitude),
-        estimatedTime: '8 min',
-        totalDistance: '2,4 km',
-        riskLevel: 'Baixo',
+        estimatedTime: durationLabel,
+        totalDistance: distanceLabel,
+        riskLevel: riskLabel,
+        routeCoordinatesJson: JSON.stringify(routeLineCoords),
+        stepsJson: JSON.stringify(safeRoute?.steps ?? []),
       },
     });
   };
@@ -318,17 +408,22 @@ export default function RouteMapScreen() {
         webPolylineRef.current = null;
       }
 
-      webPolylineRef.current = L.polyline(
-        routeLineCoords.map((coord) => [coord.latitude, coord.longitude]),
-        {
-          color: '#16A34A',
-          weight: 5,
-          opacity: 0.85,
-        },
-      ).addTo(map);
+      if (routeLineCoords.length > 1) {
+        webPolylineRef.current = L.polyline(
+          routeLineCoords.map((coord) => [coord.latitude, coord.longitude]),
+          {
+            color: '#16A34A',
+            weight: 5,
+            opacity: 0.85,
+          },
+        ).addTo(map);
+      }
 
       const bounds = L.latLngBounds(
-        routeLineCoords.map((coord) => [coord.latitude, coord.longitude]),
+        (routeLineCoords.length > 1
+          ? routeLineCoords
+          : [initialOrigin, initialDestination]
+        ).map((coord) => [coord.latitude, coord.longitude]),
       );
 
       map.fitBounds(bounds, {
@@ -374,6 +469,8 @@ export default function RouteMapScreen() {
     initialOrigin.longitude,
     initialDestination.latitude,
     initialDestination.longitude,
+    safeRoute,
+    routeLineCoords,
   ]);
 
   if (!hasRouteData) {
@@ -466,6 +563,13 @@ export default function RouteMapScreen() {
             <RouteSummaryCard
               originName={originName}
               destinationName={destinationName}
+              distanceLabel={distanceLabel}
+              durationLabel={durationLabel}
+              riskLabel={riskLabel}
+              riskDescription={riskDescription}
+              errorMessage={routeErrorMessage}
+              isLoading={isRouteLoading}
+              onRetry={loadSafeRoute}
               onStartRoute={handleStartRoute}
             />
           </View>
@@ -508,6 +612,13 @@ export default function RouteMapScreen() {
             <RouteSummaryCard
               originName={originName}
               destinationName={destinationName}
+              distanceLabel={distanceLabel}
+              durationLabel={durationLabel}
+              riskLabel={riskLabel}
+              riskDescription={riskDescription}
+              errorMessage={routeErrorMessage}
+              isLoading={isRouteLoading}
+              onRetry={loadSafeRoute}
               onStartRoute={handleStartRoute}
             />
           </View>
@@ -549,11 +660,13 @@ export default function RouteMapScreen() {
             showsMyLocationButton={false}
             toolbarEnabled={false}
           >
-            <Polyline
-              coordinates={routeLineCoords}
-              strokeColor="#16A34A"
-              strokeWidth={5}
-            />
+            {routeLineCoords.length > 1 && (
+              <Polyline
+                coordinates={routeLineCoords}
+                strokeColor="#16A34A"
+                strokeWidth={5}
+              />
+            )}
 
             <Marker
               coordinate={initialOrigin}
@@ -573,6 +686,13 @@ export default function RouteMapScreen() {
           <RouteSummaryCard
             originName={originName}
             destinationName={destinationName}
+            distanceLabel={distanceLabel}
+            durationLabel={durationLabel}
+            riskLabel={riskLabel}
+            riskDescription={riskDescription}
+            errorMessage={routeErrorMessage}
+            isLoading={isRouteLoading}
+            onRetry={loadSafeRoute}
             onStartRoute={handleStartRoute}
           />
         </View>
@@ -736,6 +856,84 @@ const styles = StyleSheet.create({
   riskBadgeText: {
     color: '#166534',
     fontSize: 11,
+    fontWeight: '800',
+  },
+
+  routeMetricsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    backgroundColor: '#F8FAFC',
+    borderRadius: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    marginBottom: 12,
+  },
+
+  routeMetricText: {
+    color: '#102A56',
+    fontSize: 12,
+    fontWeight: '800',
+  },
+
+  routeMetricSeparator: {
+    color: '#CBD5E1',
+    fontSize: 12,
+    fontWeight: '800',
+    marginHorizontal: 8,
+  },
+
+  routeFeedbackBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#ECFDF3',
+    borderRadius: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    marginBottom: 12,
+  },
+
+  routeFeedbackText: {
+    color: '#166534',
+    fontSize: 12,
+    fontWeight: '700',
+    marginLeft: 8,
+  },
+
+  routeErrorBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FEF2F2',
+    borderColor: '#FEE2E2',
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    marginBottom: 12,
+  },
+
+  routeErrorText: {
+    flex: 1,
+    color: '#DC2626',
+    fontSize: 12,
+    fontWeight: '700',
+    lineHeight: 16,
+    marginLeft: 8,
+  },
+
+  retryButton: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#FCA5A5',
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    marginLeft: 8,
+  },
+
+  retryButtonText: {
+    color: '#DC2626',
+    fontSize: 12,
     fontWeight: '800',
   },
 

--- a/frontend/components/RouteSearchScreen.tsx
+++ b/frontend/components/RouteSearchScreen.tsx
@@ -15,6 +15,8 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
+import { geocodeLocation } from '../services/geocodingService';
+import { calculateSafeRoute } from '../services/routeService';
 
 type Coordinates = {
   latitude: number;
@@ -49,29 +51,6 @@ const EMPTY_LOCATION: RouteLocationDraft = {
   text: '',
   coordinates: null,
 };
-
-const SAVED_LOCATIONS: Suggestion[] = [
- {
-  id: 'home',
-  label: 'Casa',
-  subtitle: 'Local salvo',
-  icon: 'home-outline',
-  coordinates: {
-    latitude: -5.0836,
-    longitude: -42.7934,
-  },
-},
-{
-  id: 'work',
-  label: 'Trabalho',
-  subtitle: 'Local salvo',
-  icon: 'briefcase-outline',
-  coordinates: {
-    latitude: -5.0805,
-    longitude: -42.7901,
-  },
-},
-]
 
 const RECENT_LOCATIONS: Suggestion[] = [
   {
@@ -139,6 +118,21 @@ const POPULAR_REGIONS: Suggestion[] = [
   },
 ];
 
+async function resolveRouteLocation(location: RouteLocationDraft): Promise<RouteLocationDraft> {
+  if (location.coordinates) {
+    return location;
+  }
+
+  const geocodedLocation = await geocodeLocation(location.text);
+
+  return {
+    text: location.text.trim() || geocodedLocation.label,
+    coordinates: {
+      latitude: geocodedLocation.latitude,
+      longitude: geocodedLocation.longitude,
+    },
+  };
+}
 
 export default function RouteSearchScreen({ onSearch }: RouteSearchScreenProps) {
   const router = useRouter();
@@ -148,8 +142,8 @@ export default function RouteSearchScreen({ onSearch }: RouteSearchScreenProps) 
     useState<RouteLocationDraft>(EMPTY_LOCATION);
 
   const [activeField, setActiveField] = useState<FieldName>('origin');
-  const [routeDraft, setRouteDraft] = useState<RouteSearchData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const isFormValid =
     origin.text.trim().length > 0 && destination.text.trim().length > 0;
@@ -161,7 +155,7 @@ export default function RouteSearchScreen({ onSearch }: RouteSearchScreenProps) 
     });
 
     setActiveField('origin');
-    setRouteDraft(null);
+    setErrorMessage(null);
   };
 
   const handleChangeDestination = (value: string) => {
@@ -171,14 +165,14 @@ export default function RouteSearchScreen({ onSearch }: RouteSearchScreenProps) 
     });
 
     setActiveField('destination');
-    setRouteDraft(null);
+    setErrorMessage(null);
   };
 
   const handleClearOrigin = () => {
     if (isLoading) return;
 
     setOrigin(EMPTY_LOCATION);
-    setRouteDraft(null);
+    setErrorMessage(null);
     setActiveField('origin');
   };
 
@@ -186,7 +180,7 @@ export default function RouteSearchScreen({ onSearch }: RouteSearchScreenProps) 
     if (isLoading) return;
 
     setDestination(EMPTY_LOCATION);
-    setRouteDraft(null);
+    setErrorMessage(null);
     setActiveField('destination');
   };
 
@@ -202,7 +196,7 @@ export default function RouteSearchScreen({ onSearch }: RouteSearchScreenProps) 
       setDestination(selectedLocation);
     }
 
-    setRouteDraft(null);
+    setErrorMessage(null);
   };
 
   const prepareRouteDraft = (): RouteSearchData => {
@@ -222,48 +216,45 @@ export default function RouteSearchScreen({ onSearch }: RouteSearchScreenProps) 
   if (!isFormValid || isLoading) return;
 
   setIsLoading(true);
+  setErrorMessage(null);
 
   try {
-    const preparedRouteDraft = prepareRouteDraft();
+    const draft = prepareRouteDraft();
+    const preparedRouteDraft: RouteSearchData = {
+      origin: await resolveRouteLocation(draft.origin),
+      destination: await resolveRouteLocation(draft.destination),
+    };
 
-    setRouteDraft(preparedRouteDraft);
+    const originCoordinates = preparedRouteDraft.origin.coordinates;
+    const destinationCoordinates = preparedRouteDraft.destination.coordinates;
+
+    if (!originCoordinates || !destinationCoordinates) {
+      throw new Error('Nao foi possivel encontrar coordenadas para origem e destino.');
+    }
 
     if (onSearch) {
       await onSearch(preparedRouteDraft);
-    } else {
-      await new Promise((resolve) => setTimeout(resolve, 900));
     }
 
-    console.log(
-      'Dados disponíveis para requisição de rota:',
-      preparedRouteDraft,
-    );
+    const safeRoute = await calculateSafeRoute({
+      origin: originCoordinates,
+      destination: destinationCoordinates,
+    });
 
     router.push({
       pathname: '/route-map',
       params: {
         originName: preparedRouteDraft.origin.text,
         destinationName: preparedRouteDraft.destination.text,
-        originLatitude:
-          preparedRouteDraft.origin.coordinates?.latitude !== undefined
-            ? String(preparedRouteDraft.origin.coordinates.latitude)
-            : '',
-        originLongitude:
-          preparedRouteDraft.origin.coordinates?.longitude !== undefined
-            ? String(preparedRouteDraft.origin.coordinates.longitude)
-            : '',
-        destinationLatitude:
-          preparedRouteDraft.destination.coordinates?.latitude !== undefined
-            ? String(preparedRouteDraft.destination.coordinates.latitude)
-            : '',
-        destinationLongitude:
-          preparedRouteDraft.destination.coordinates?.longitude !== undefined
-            ? String(preparedRouteDraft.destination.coordinates.longitude)
-            : '',
+        originLatitude: String(originCoordinates.latitude),
+        originLongitude: String(originCoordinates.longitude),
+        destinationLatitude: String(destinationCoordinates.latitude),
+        destinationLongitude: String(destinationCoordinates.longitude),
+        routeData: JSON.stringify(safeRoute),
       },
     });
-  } catch (error) {
-    console.error('Erro ao preparar rota:', error);
+  } catch (error: any) {
+    setErrorMessage(error?.message || 'Nao foi possivel calcular a rota segura. Tente novamente.');
   } finally {
     setIsLoading(false);
   }
@@ -488,6 +479,13 @@ export default function RouteSearchScreen({ onSearch }: RouteSearchScreenProps) 
                 </Text>
               )}
 
+              {errorMessage && (
+                <View style={styles.errorBox}>
+                  <Ionicons name="alert-circle-outline" size={18} color="#DC2626" />
+                  <Text style={styles.errorText}>{errorMessage}</Text>
+                </View>
+              )}
+
 
               <View style={styles.suggestionsCard}>
                 <View style={styles.suggestionsHeader}>
@@ -496,38 +494,6 @@ export default function RouteSearchScreen({ onSearch }: RouteSearchScreenProps) 
                       ? 'Escolha sua origem'
                       : 'Escolha seu destino'}
                   </Text>
-                </View>
-
-                <View style={styles.savedSection}>
-                  <Text style={styles.suggestionSectionTitle}>
-                    Locais salvos
-                  </Text>
-
-                  <View style={styles.savedLocationsRow}>
-                    {SAVED_LOCATIONS.map((suggestion) => (
-                      <TouchableOpacity
-                        key={suggestion.id}
-                        style={styles.savedLocationCard}
-                        onPress={() => handleSelectSuggestion(suggestion)}
-                        activeOpacity={0.75}
-                      >
-                        <View style={styles.savedLocationIcon}>
-                          <Ionicons
-                            name={suggestion.icon}
-                            size={20}
-                            color="#16A34A"
-                          />
-                        </View>
-
-                        <Text style={styles.savedLocationTitle}>
-                          {suggestion.label}
-                        </Text>
-                        <Text style={styles.savedLocationSubtitle}>
-                          {suggestion.subtitle}
-                        </Text>
-                      </TouchableOpacity>
-                    ))}
-                  </View>
                 </View>
 
                 {renderSuggestionSection('Buscas recentes', RECENT_LOCATIONS)}
@@ -750,6 +716,27 @@ const styles = StyleSheet.create({
     marginTop: 8,
   },
 
+  errorBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FEF2F2',
+    borderColor: '#FEE2E2',
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginTop: 10,
+  },
+
+  errorText: {
+    flex: 1,
+    color: '#DC2626',
+    fontSize: 13,
+    fontWeight: '700',
+    lineHeight: 18,
+    marginLeft: 8,
+  },
+
   draftCard: {
     flexDirection: 'row',
     alignItems: 'flex-start',
@@ -803,47 +790,6 @@ const styles = StyleSheet.create({
 
   savedSection: {
     paddingTop: 4,
-  },
-
-  savedLocationsRow: {
-    flexDirection: 'row',
-    gap: 10,
-    paddingHorizontal: 14,
-    paddingTop: 6,
-    paddingBottom: 10,
-  },
-
-  savedLocationCard: {
-    flex: 1,
-    backgroundColor: '#F8FAFC',
-    borderRadius: 14,
-    borderWidth: 1,
-    borderColor: '#E5EAF0',
-    padding: 12,
-    alignItems: 'flex-start',
-  },
-
-  savedLocationIcon: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: '#ECFDF3',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 10,
-  },
-
-  savedLocationTitle: {
-    color: '#102A56',
-    fontSize: 14,
-    fontWeight: '800',
-    marginBottom: 2,
-  },
-
-  savedLocationSubtitle: {
-    color: '#64748B',
-    fontSize: 12,
-    fontWeight: '500',
   },
 
   suggestionSection: {

--- a/frontend/hooks/useShareTrip.ts
+++ b/frontend/hooks/useShareTrip.ts
@@ -1,6 +1,23 @@
 import { useState, useCallback } from 'react';
 import * as Clipboard from 'expo-clipboard';
-import { shareService, ShareSession } from '../services/shareService';
+import { shareService, ShareCoordinate, ShareSession } from '../services/shareService';
+
+type UseShareTripResult = {
+  activeSession: ShareSession | null;
+  isStarting: boolean;
+  isStopping: boolean;
+  isCopying: boolean;
+  errorMessage: string | null;
+  successMessage: string | null;
+  startSharing: (
+    currentLocation: ShareCoordinate,
+    destination: ShareCoordinate,
+  ) => Promise<void>;
+  stopSharing: () => Promise<void>;
+  copyShareLink: () => Promise<void>;
+  updateSharingLocation: (location: ShareCoordinate) => Promise<void>;
+  clearMessages: () => void;
+};
 
 export function useShareTrip() {
   const [activeSession, setActiveSession] = useState<ShareSession | null>(null);
@@ -69,6 +86,17 @@ export function useShareTrip() {
     }
   }, [activeSession, clearMessages]);
 
+  const updateSharingLocation = useCallback(async (location: ShareCoordinate) => {
+    if (!activeSession) return;
+
+    try {
+      await shareService.updateLocation(activeSession.token, location);
+    } catch (err: any) {
+      setErrorMessage('Nao foi possivel atualizar a localizacao compartilhada.');
+      setTimeout(() => setErrorMessage(null), 3000);
+    }
+  }, [activeSession]);
+
   return {
     activeSession,
     isStarting,
@@ -79,6 +107,7 @@ export function useShareTrip() {
     startSharing,
     stopSharing,
     copyShareLink,
+    updateSharingLocation,
     clearMessages,
-  };
+  } satisfies UseShareTripResult;
 }

--- a/frontend/services/__tests__/routeService.test.ts
+++ b/frontend/services/__tests__/routeService.test.ts
@@ -19,7 +19,7 @@ function mockJsonResponse(status: number, body: unknown) {
 
 describe('routeService', () => {
   beforeEach(() => {
-    global.fetch = jest.fn();
+    (globalThis as any).fetch = jest.fn();
   });
 
   afterEach(() => {
@@ -58,7 +58,7 @@ describe('routeService', () => {
       nearbyOccurrences: [],
     };
 
-    (global.fetch as jest.Mock).mockImplementationOnce(() => mockJsonResponse(200, apiResponse));
+    ((globalThis as any).fetch as jest.Mock).mockImplementationOnce(() => mockJsonResponse(200, apiResponse));
 
     const payload = {
       origin: { latitude: -5.0892, longitude: -42.8016 },
@@ -67,7 +67,7 @@ describe('routeService', () => {
 
     const result = await calculateSafeRoute(payload);
 
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect((globalThis as any).fetch).toHaveBeenCalledWith(
       'http://api.test/api/routes/safe',
       expect.objectContaining({
         method: 'POST',
@@ -80,7 +80,7 @@ describe('routeService', () => {
   });
 
   it('deve tratar erro retornado pelo backend', async () => {
-    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+    ((globalThis as any).fetch as jest.Mock).mockImplementationOnce(() =>
       mockJsonResponse(400, { detail: 'Origin must contain latitude and longitude' })
     );
 
@@ -100,7 +100,7 @@ describe('routeService', () => {
   });
 
   it('deve tratar falha de rede com mensagem compreensivel', async () => {
-    (global.fetch as jest.Mock).mockRejectedValueOnce(new TypeError('Network request failed'));
+    ((globalThis as any).fetch as jest.Mock).mockRejectedValueOnce(new TypeError('Network request failed'));
 
     await expect(
       calculateSafeRoute({

--- a/frontend/services/__tests__/routeService.test.ts
+++ b/frontend/services/__tests__/routeService.test.ts
@@ -1,0 +1,118 @@
+import {
+  calculateSafeRoute,
+  formatRiskLevel,
+  formatRouteDistance,
+  formatRouteDuration,
+} from '../routeService';
+
+jest.mock('../../config/api', () => ({
+  API_URL: 'http://api.test',
+}));
+
+function mockJsonResponse(status: number, body: unknown) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response);
+}
+
+describe('routeService', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('deve enviar origem e destino para o endpoint de rota segura', async () => {
+    const apiResponse = {
+      status: 'success',
+      distance: 1250.5,
+      duration: 420,
+      geometry: [
+        { latitude: -5.0892, longitude: -42.8016 },
+        { latitude: -5.092, longitude: -42.81 },
+      ],
+      distanceMeters: 1250.5,
+      durationSeconds: 420,
+      risk: {
+        level: 'LOW',
+        score: 3,
+        description: 'Rota com baixo risco identificado.',
+        nearbyOccurrencesCount: 1,
+        intersectedRiskZonesCount: 0,
+      },
+      route: {
+        type: 'LineString',
+        coordinates: [
+          [-42.8016, -5.0892],
+          [-42.81, -5.092],
+        ],
+      },
+      points: [
+        { latitude: -5.0892, longitude: -42.8016 },
+        { latitude: -5.092, longitude: -42.81 },
+      ],
+      nearbyOccurrences: [],
+    };
+
+    (global.fetch as jest.Mock).mockImplementationOnce(() => mockJsonResponse(200, apiResponse));
+
+    const payload = {
+      origin: { latitude: -5.0892, longitude: -42.8016 },
+      destination: { latitude: -5.092, longitude: -42.81 },
+    };
+
+    const result = await calculateSafeRoute(payload);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://api.test/api/routes/safe',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+      })
+    );
+    expect(result.points).toHaveLength(2);
+    expect(result.distanceMeters).toBe(1250.5);
+    expect(result.risk.level).toBe('LOW');
+  });
+
+  it('deve tratar erro retornado pelo backend', async () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() =>
+      mockJsonResponse(400, { detail: 'Origin must contain latitude and longitude' })
+    );
+
+    await expect(
+      calculateSafeRoute({
+        origin: { latitude: Number.NaN, longitude: -42.8016 },
+        destination: { latitude: -5.092, longitude: -42.81 },
+      })
+    ).rejects.toThrow('Origem deve ter latitude e longitude validas.');
+
+    await expect(
+      calculateSafeRoute({
+        origin: { latitude: -5.0892, longitude: -42.8016 },
+        destination: { latitude: -5.092, longitude: -42.81 },
+      })
+    ).rejects.toThrow('Origin must contain latitude and longitude');
+  });
+
+  it('deve tratar falha de rede com mensagem compreensivel', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new TypeError('Network request failed'));
+
+    await expect(
+      calculateSafeRoute({
+        origin: { latitude: -5.0892, longitude: -42.8016 },
+        destination: { latitude: -5.092, longitude: -42.81 },
+      })
+    ).rejects.toThrow('Nao foi possivel conectar ao servidor de rotas.');
+  });
+
+  it('deve formatar informacoes basicas da rota', () => {
+    expect(formatRouteDistance(1250)).toBe('1,3 km');
+    expect(formatRouteDuration(420)).toBe('7 min');
+    expect(formatRiskLevel('HIGH')).toBe('Alto risco');
+  });
+});

--- a/frontend/services/geocodingService.ts
+++ b/frontend/services/geocodingService.ts
@@ -1,0 +1,59 @@
+import { API_URL } from '../config/api';
+import { RouteCoordinate, RouteServiceError } from './routeService';
+
+export type GeocodedLocation = RouteCoordinate & {
+  label: string;
+};
+
+async function readErrorMessage(response: Response): Promise<string> {
+  const data = await response.json().catch(() => null);
+  return data?.detail || data?.message || `Nao foi possivel buscar o endereco (${response.status}).`;
+}
+
+function isLikelyMapLink(query: string): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return (
+    normalizedQuery.startsWith('http://') ||
+    normalizedQuery.startsWith('https://') ||
+    normalizedQuery.includes('google.com/maps') ||
+    normalizedQuery.includes('maps.app.goo.gl') ||
+    normalizedQuery.includes('goo.gl/maps')
+  );
+}
+
+export async function geocodeLocation(query: string): Promise<GeocodedLocation> {
+  const normalizedQuery = query.trim();
+
+  if (normalizedQuery.length < 3) {
+    throw new RouteServiceError('Digite um endereco com pelo menos 3 caracteres.');
+  }
+
+  if (isLikelyMapLink(normalizedQuery)) {
+    throw new RouteServiceError(
+      'Cole o endereco em texto, nao o link do Google Maps. Exemplo: Rua, bairro, cidade, estado.'
+    );
+  }
+
+  const response = await fetch(
+    `${API_URL}/api/routes/geocode?query=${encodeURIComponent(normalizedQuery)}`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new RouteServiceError(await readErrorMessage(response), response.status);
+  }
+
+  const data = (await response.json()) as GeocodedLocation;
+
+  if (!Number.isFinite(data.latitude) || !Number.isFinite(data.longitude)) {
+    throw new RouteServiceError('Endereco encontrado sem coordenadas validas.');
+  }
+
+  return data;
+}

--- a/frontend/services/routeService.ts
+++ b/frontend/services/routeService.ts
@@ -1,28 +1,153 @@
+import { API_URL } from '../config/api';
+
+export type RouteCoordinate = {
+  latitude: number;
+  longitude: number;
+};
+
+export type SafeRouteRiskLevel = 'LOW' | 'MEDIUM' | 'HIGH' | string;
+
 export interface SafeRouteSearchPayload {
-  origin: string;
-  destination: string;
+  origin: RouteCoordinate;
+  destination: RouteCoordinate;
+}
+
+export interface SafeRouteRisk {
+  level: SafeRouteRiskLevel;
+  score: number;
+  description: string;
+  nearbyOccurrencesCount: number;
+  intersectedRiskZonesCount: number;
+}
+
+export interface NearbyOccurrence {
+  id: string | number;
+  type: string;
+  latitude: number;
+  longitude: number;
+  distanceFromRouteMeters: number;
+}
+
+export type NavigationManeuver = 'straight' | 'left' | 'right' | 'arrive' | string;
+
+export interface SafeRouteStep {
+  instruction: string;
+  streetName: string;
+  nextInstruction: string;
+  distance: string;
+  maneuver: NavigationManeuver;
+  routePointIndex?: number | null;
 }
 
 export interface SafeRouteSearchResult {
-  success: true;
+  status: string;
+  distance: number;
+  duration: number;
+  geometry: RouteCoordinate[];
+  distanceMeters: number;
+  durationSeconds: number;
+  risk: SafeRouteRisk;
+  route: {
+    type: 'LineString' | string;
+    coordinates: [number, number][];
+  };
+  points: RouteCoordinate[];
+  steps: SafeRouteStep[];
+  nearbyOccurrences: NearbyOccurrence[];
 }
 
-const SIMULATE_ROUTE_ERROR = false;
+export class RouteServiceError extends Error {
+  status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'RouteServiceError';
+    this.status = status;
+  }
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  const data = await response.json().catch(() => null);
+  return data?.detail || data?.message || `Nao foi possivel calcular a rota (${response.status}).`;
+}
+
+function assertValidCoordinate(name: string, coordinate: RouteCoordinate) {
+  if (
+    coordinate == null ||
+    !Number.isFinite(coordinate.latitude) ||
+    !Number.isFinite(coordinate.longitude)
+  ) {
+    throw new RouteServiceError(`${name} deve ter latitude e longitude validas.`);
+  }
+}
 
 export async function calculateSafeRoute({
   origin,
   destination,
 }: SafeRouteSearchPayload): Promise<SafeRouteSearchResult> {
-  if (!origin.trim() || !destination.trim()) {
-    throw new Error('Origem e destino sao obrigatorios.');
+  assertValidCoordinate('Origem', origin);
+  assertValidCoordinate('Destino', destination);
+
+  try {
+    const response = await fetch(`${API_URL}/api/routes/safe`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ origin, destination }),
+    });
+
+    if (!response.ok) {
+      throw new RouteServiceError(await readErrorMessage(response), response.status);
+    }
+
+    return (await response.json()) as SafeRouteSearchResult;
+  } catch (error) {
+    if (error instanceof RouteServiceError) {
+      throw error;
+    }
+
+    throw new RouteServiceError(
+      'Nao foi possivel conectar ao servidor de rotas. Verifique sua conexao e tente novamente.'
+    );
+  }
+}
+
+export function formatRouteDistance(distanceMeters: number): string {
+  if (!Number.isFinite(distanceMeters)) return '-- km';
+
+  if (distanceMeters < 1000) {
+    return `${Math.round(distanceMeters)} m`;
   }
 
-  // TODO: Integrar com o backend de rotas seguras quando o endpoint estiver disponivel.
-  await new Promise((resolve) => setTimeout(resolve, 900));
+  return `${(distanceMeters / 1000).toFixed(1).replace('.', ',')} km`;
+}
 
-  if (SIMULATE_ROUTE_ERROR) {
-    throw new Error('Erro simulado ao calcular rota.');
+export function formatRouteDuration(durationSeconds: number): string {
+  if (!Number.isFinite(durationSeconds)) return '-- min';
+
+  const minutes = Math.max(1, Math.round(durationSeconds / 60));
+
+  if (minutes < 60) {
+    return `${minutes} min`;
   }
 
-  return { success: true };
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}min` : `${hours}h`;
+}
+
+export function formatRiskLevel(level: SafeRouteRiskLevel): string {
+  switch (level) {
+    case 'LOW':
+      return 'Baixo risco';
+    case 'MEDIUM':
+      return 'Risco moderado';
+    case 'HIGH':
+      return 'Alto risco';
+    default:
+      return 'Risco indisponivel';
+  }
 }

--- a/frontend/services/shareService.ts
+++ b/frontend/services/shareService.ts
@@ -1,5 +1,10 @@
 import { API_URL } from '../config/api';
 
+export interface ShareCoordinate {
+  latitude: number;
+  longitude: number;
+}
+
 export interface ShareSession {
   id: string;
   token: string;
@@ -11,9 +16,9 @@ export interface ShareSession {
 
 export interface SharedRouteDetails {
   status: 'active' | 'ended' | 'expired';
-  origin: { latitude: number; longitude: number };
-  currentLocation: { latitude: number; longitude: number };
-  destination: { latitude: number; longitude: number };
+  origin: ShareCoordinate;
+  currentLocation: ShareCoordinate;
+  destination: ShareCoordinate;
   lastUpdatedAt: string;
 }
 
@@ -45,6 +50,26 @@ export const shareService = {
   async stopSharing(token: string): Promise<void> {
     // Simular latência de rede de 800ms
     await new Promise((resolve) => setTimeout(resolve, 800));
+  },
+
+  async updateLocation(token: string, location: ShareCoordinate): Promise<void> {
+    try {
+      const response = await fetch(`${API_URL}/api/mock/sharing-sessions/${token}/location`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(location),
+      });
+
+      if (!response.ok) {
+        throw new Error('SHARING_LOCATION_UPDATE_FAILED');
+      }
+    } catch {
+      // Mantém o fluxo resiliente enquanto a integração completa ainda não está pronta.
+      return;
+    }
   },
 
   /**


### PR DESCRIPTION
## O que foi feito
Foi adicionada uma mensagem estática de resumo da rota em frontend/components/ActiveRouteScreen.tsx, com distância, duração e nível de risco já definidos para depois ligar ao backend.

A navegação ativa foi compactada na frontend/components/ActiveRouteScreen.tsx: o marcador do usuário foi ajustado e os steps ficaram só no topo, para não estourar a tela.

O texto e o ícone de “resumo da rota” no card inferior foram removidos, deixando a interface mais limpa.

Na busca de endereço, foi adicionada validação para bloquear links do Google Maps e orientar o usuário a digitar o endereço em texto puro em frontend/services/geocodingService.ts

Realizando a integração do backend com frontend

## Issue

Closes #91 