### PR TITLE
feat: Alterar cor do marcador de localização. Closes #38

### DIFF
--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -270,6 +270,7 @@ export default function HomeScreen() {
             const cleanId = id.replace('mock-', '');
             setActiveReviewId(cleanId);
           }}
+          riskLevel={areaRisk.level}
         />
 
         {/* Top Header overlaying the map */}

--- a/frontend/components/ActiveRouteScreen.tsx
+++ b/frontend/components/ActiveRouteScreen.tsx
@@ -80,6 +80,29 @@ const FALLBACK_DESTINATION: RouteCoordinates = {
   longitude: -42.7901,
 };
 
+const getRiskColors = (level: string) => {
+  const normalized = level.toLowerCase();
+  if (normalized.includes('baixo')) {
+    return {
+      hex: '#16A34A',
+      rgba: 'rgba(22, 163, 74, 0.16)',
+    };
+  } else if (normalized.includes('moderado') || normalized.includes('medio') || normalized.includes('médio')) {
+    return {
+      hex: '#EAB308',
+      rgba: 'rgba(234, 179, 8, 0.16)',
+    };
+  } else if (normalized.includes('alto')) {
+    return {
+      hex: '#DC2626',
+      rgba: 'rgba(220, 38, 38, 0.16)',
+    };
+  }
+  return {
+    hex: '#1473E6',
+    rgba: 'rgba(20, 115, 230, 0.16)',
+  };
+};
 
 const MOCK_ACTIVE_ROUTE = {
   currentStepIndex: 0,
@@ -312,6 +335,7 @@ type ActiveRouteMapProps = {
   destinationName: string;
   routeCoordinates: RouteCoordinates[];
   recenterSignal: number;
+  riskLevel: string;
 };
 
 function ActiveRouteMap({
@@ -322,8 +346,10 @@ function ActiveRouteMap({
   destinationName,
   routeCoordinates,
   recenterSignal,
+  riskLevel,
 }: ActiveRouteMapProps) {
   const isWeb = Platform.OS === 'web';
+  const riskColors = getRiskColors(riskLevel);
   const webMapId = 'active-route-map-leaflet';
 
   const webMapRef = useRef<any>(null);
@@ -449,33 +475,26 @@ function ActiveRouteMap({
         className: 'user-current-icon',
         html: `
           <div style="
-            width:48px;
-            height:48px;
-            border-radius:24px;
-            background:rgba(20,115,230,0.16);
+            width:32px;
+            height:32px;
+            border-radius:50%;
+            background:${riskColors.rgba};
             display:flex;
             align-items:center;
             justify-content:center;
           ">
             <div style="
-              width:38px;
-              height:38px;
-              border-radius:19px;
-              background:white;
-              display:flex;
-              align-items:center;
-              justify-content:center;
-              box-shadow:0 5px 12px rgba(0,0,0,0.25);
-              color:#1473E6;
-              font-size:21px;
-              font-weight:900;
-            ">
-              ➤
-            </div>
+              width:16px;
+              height:16px;
+              border-radius:50%;
+              background:${riskColors.hex};
+              border:2px solid white;
+              box-shadow:0 0 6px rgba(0,0,0,0.3);
+            "></div>
           </div>
         `,
-        iconSize: [48, 48],
-        iconAnchor: [24, 24],
+        iconSize: [32, 32],
+        iconAnchor: [16, 16],
       });
 
       const originMarker = L.marker([origin.latitude, origin.longitude], {
@@ -570,6 +589,7 @@ function ActiveRouteMap({
     routeCoordinates,
     mapInitialRegion.latitude,
     mapInitialRegion.longitude,
+    riskLevel,
   ]);
 
   useEffect(() => {
@@ -645,11 +665,25 @@ function ActiveRouteMap({
       <Marker
         coordinate={currentLocation}
         title="Posicao simulada"
-        image={USER_LOCATION_MARKER}
         anchor={{ x: 0.5, y: 0.5 }}
         centerOffset={{ x: 0, y: 0 }}
         zIndex={10}
-      />
+      >
+        <View
+          style={[
+            styles.nativeUserMarkerOuter,
+            { backgroundColor: riskColors.rgba },
+          ]}
+          testID="user-location-marker-dot"
+        >
+          <View
+            style={[
+              styles.nativeUserMarkerInnerDot,
+              { backgroundColor: riskColors.hex },
+            ]}
+          />
+        </View>
+      </Marker>
     </MapView>
   );
 }
@@ -1052,6 +1086,7 @@ export default function ActiveRouteScreen() {
           destinationName={destinationName}
           routeCoordinates={routeCoordinates}
           recenterSignal={recenterSignal}
+          riskLevel={riskLevel}
         />
 
         <TopInstructionCard
@@ -1567,5 +1602,29 @@ const styles = StyleSheet.create({
     color: COLORS.white,
     fontSize: 15,
     fontWeight: '800',
+  },
+
+  nativeUserMarkerOuter: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  nativeUserMarkerInnerDot: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    borderWidth: 2,
+    borderColor: '#FFFFFF',
+    shadowColor: '#000000',
+    shadowOpacity: 0.3,
+    shadowRadius: 3,
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    elevation: 3,
   },
 });

--- a/frontend/components/MapScreen.tsx
+++ b/frontend/components/MapScreen.tsx
@@ -24,6 +24,29 @@ export const getCategoryColor = (category: string): string => {
       return '#4b5563';
   }
 };
+const getRiskColors = (level: string) => {
+  const normalized = level.toLowerCase();
+  if (normalized.includes('baixo') || normalized.includes('azul') || normalized.includes('low')) {
+    return {
+      hex: '#036D9A',
+      rgba: 'rgba(3, 109, 154, 0.16)',
+    };
+  } else if (normalized.includes('moderado') || normalized.includes('medio') || normalized.includes('médio') || normalized.includes('amarelo') || normalized.includes('medium')) {
+    return {
+      hex: '#EAB308',
+      rgba: 'rgba(234, 179, 8, 0.16)',
+    };
+  } else if (normalized.includes('alto') || normalized.includes('vermelho') || normalized.includes('high')) {
+    return {
+      hex: '#CF0000',
+      rgba: 'rgba(207, 0, 0, 0.16)',
+    };
+  }
+  return {
+    hex: '#036D9A',
+    rgba: 'rgba(3, 109, 154, 0.16)',
+  };
+};
 
 let MapView: any = null;
 let Marker: any = null;
@@ -52,6 +75,7 @@ interface MapScreenProps {
   onRecenterPress?: () => Promise<void> | void;
   isRightHanded?: boolean;
   onReviewPress?: (id: string) => void;
+  riskLevel?: string;
 }
 
 export interface MapScreenRef {
@@ -68,10 +92,12 @@ const MapScreen = React.forwardRef<MapScreenRef, MapScreenProps>(function MapScr
     onRecenterPress,
     isRightHanded = true,
     onReviewPress,
+    riskLevel = 'AZUL',
   },
   ref
 ) {
   const isWeb = Platform.OS === 'web';
+  const riskColors = getRiskColors(riskLevel);
   const webMapId = 'leaflet-map-container';
 
   const mapCenterRef = useRef<[number, number] | null>(null);
@@ -79,6 +105,7 @@ const MapScreen = React.forwardRef<MapScreenRef, MapScreenProps>(function MapScr
   const webMapRef = useRef<any>(null);
   const webMarkersRef = useRef<any[]>([]);
   const webSelectedMarkerRef = useRef<any>(null);
+  const webUserMarkerRef = useRef<any>(null);
   const nativeMapRef = useRef<any>(null);
   const hasCenteredOnUserRef = useRef<boolean>(false);
   const forceCenterRef = useRef<boolean>(false);
@@ -296,7 +323,46 @@ const MapScreen = React.forwardRef<MapScreenRef, MapScreenProps>(function MapScr
         .openPopup();
       webSelectedMarkerRef.current = marker;
     }
-  }, [reviews, selectedPoint, isWeb, mapReady]);
+
+    if (webUserMarkerRef.current) {
+      webUserMarkerRef.current.remove();
+      webUserMarkerRef.current = null;
+    }
+
+    if (userLocation) {
+      const riskColors = getRiskColors(riskLevel);
+      const userIcon = L.divIcon({
+        className: 'user-current-icon',
+        html: `
+          <div style="
+            width:32px;
+            height:32px;
+            border-radius:50%;
+            background:${riskColors.rgba};
+            display:flex;
+            align-items:center;
+            justify-content:center;
+          ">
+            <div style="
+              width:16px;
+              height:16px;
+              border-radius:50%;
+              background:${riskColors.hex};
+              border:2px solid white;
+              box-shadow:0 0 6px rgba(0,0,0,0.3);
+            "></div>
+          </div>
+        `,
+        iconSize: [32, 32],
+        iconAnchor: [16, 16],
+      });
+
+      const userMarker = L.marker([userLocation.latitude, userLocation.longitude], { icon: userIcon })
+        .addTo(map)
+        .bindPopup('<b>Você</b>');
+      webUserMarkerRef.current = userMarker;
+    }
+  }, [reviews, selectedPoint, userLocation, riskLevel, isWeb, mapReady]);
 
   if (isWeb) {
     return (
@@ -327,7 +393,7 @@ const MapScreen = React.forwardRef<MapScreenRef, MapScreenProps>(function MapScr
         ref={nativeMapRef}
         style={styles.map}
         initialRegion={defaultRegion}
-        showsUserLocation={true}
+        showsUserLocation={false}
         showsMyLocationButton={false}
         followsUserLocation={false}
         toolbarEnabled={false}
@@ -362,6 +428,30 @@ const MapScreen = React.forwardRef<MapScreenRef, MapScreenProps>(function MapScr
             pinColor="#ea580c"
           />
         ) : null}
+
+        {userLocation && (
+          <Marker
+            coordinate={userLocation}
+            title="Sua Localização"
+            anchor={{ x: 0.5, y: 0.5 }}
+            centerOffset={{ x: 0, y: 0 }}
+            zIndex={10}
+          >
+            <View
+              style={[
+                styles.nativeUserMarkerOuter,
+                { backgroundColor: riskColors.rgba },
+              ]}
+            >
+              <View
+                style={[
+                  styles.nativeUserMarkerInnerDot,
+                  { backgroundColor: riskColors.hex },
+                ]}
+              />
+            </View>
+          </Marker>
+        )}
       </MapView>
     </View>
   );
@@ -394,5 +484,28 @@ const styles = StyleSheet.create({
   fallbackText: {
     color: '#cbd5e1',
     fontSize: 16,
+  },
+  nativeUserMarkerOuter: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  nativeUserMarkerInnerDot: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    borderWidth: 2,
+    borderColor: '#FFFFFF',
+    shadowColor: '#000000',
+    shadowOpacity: 0.3,
+    shadowRadius: 3,
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    elevation: 3,
   },
 });


### PR DESCRIPTION
## Descrição
Implementa a alteração dinâmica de cor do marcador de localização do usuário no mapa com base no nível de risco calculado para a região em que ele se encontra (na tela inicial) ou para a rota sendo percorrida (na tela de navegação ativa).
## O que foi feito
- **Mapeamento de Cores por Risco:** Criação da função auxiliar `getRiskColors` para traduzir os níveis de risco (Baixo/AZUL, Moderado/AMARELO, Alto/VERMELHO) nas cores do design system, fornecendo tanto a cor sólida (Hex) quanto a cor da aura externa (RGBA).
- **Tela de Mapa Inicial (MapScreen & index.tsx):**
  - Desativação do ponto azul estático padrão do sistema operacional (`showsUserLocation={false}`).
  - Criação de um marcador customizado reativo que acompanha a posição do GPS do usuário e muda de cor conforme a prop `riskLevel` recebida do estado `areaRisk.level` da HomeScreen.
  - Inserção do marcador de localização do usuário também no mapa Web (Leaflet) de forma reativa.
- **Tela de Rota Ativa (ActiveRouteScreen):**
  - Atualização do componente de mapa nativo e web para receber a prop `riskLevel` e re-renderizar a cor do marcador dinamicamente.
- **Identidade Visual Circular:**
  - Substituição do design anterior com símbolo de seta (`➤`) por um layout circular limpo e minimalista: um ponto central colorido com borda branca sólida de 2px envolto por uma aura pulsante semitransparente.
  - Atualização das folhas de estilo (`StyleSheet`) de ambos os arquivos para comportar o novo visual circular (`nativeUserMarkerInnerDot`).
## Issue
Closes #38 